### PR TITLE
Fix all findings from full-repository audit (v0.6.0)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,32 +13,30 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    # services:
-    #   redis:
-    #     image: redis
-    #     ports:
-    #       - 6379:6379
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.12'  # pinned: Python 3.14 + LMDB env-handle issue (#9)
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-        pip install pytest pytest-cov build twine
     - name: Check installation
       run: pip list | grep hashstash
     - name: Run tests with coverage
-      run: |
-          export PYTHONPATH=$PYTHONPATH:$(pwd)
-          pytest --cov=./ --cov-report=xml
-      env:
-        REDIS_URL: redis://localhost:6379
-
+      run: pytest --cov=hashstash --cov-report=xml
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4
       with:
@@ -50,7 +48,7 @@ jobs:
     needs: [tests]
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Releasing"
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
@@ -64,15 +62,14 @@ jobs:
     needs: [tests, github-release]
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'  # pinned: Python 3.14 + LMDB env-handle issue (#9)
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[extra,dev,test]
           pip install build twine
       - name: Build and publish
         env:
@@ -80,4 +77,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           python -m build
-          twine upload dist/*
+          twine upload --skip-existing dist/*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev]
+        pip install -e .[dev]
     - name: Check installation
       run: pip list | grep hashstash
     - name: Run tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,17 @@
 name: Test and Coverage
 
-# Run on every push and on every PR. The old filter ['*', '!main'] never
-# matched PRs into main (the branches filter applies to the BASE branch) nor
-# slash-named branches ('*' does not match '/'), so the normal PR flow was
-# never tested.
+# PRs carry branch CI (the old filter ['*', '!main'] never matched PRs into
+# main — the branches filter applies to the BASE branch — so the normal PR
+# flow was never tested). push is limited to main: running both events on a
+# PR branch produced duplicate runs whose cancelled twins cluttered the merge
+# box as "failing" checks. Use workflow_dispatch for ad-hoc branch runs.
 on:
   push:
-    branches: ['**']
+    branches: [main, master]
   pull_request:
   workflow_dispatch:
 
-# a branch with an open PR triggers both push and pull_request runs of the
-# same commit: keep only the newest run per branch
+# rapid successive pushes to a PR: keep only the newest run
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -37,7 +37,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev]
+        pip install -e .[dev]
     - name: Run tests with coverage
       run: pytest --cov=hashstash --cov-report=xml
     - name: Upload results to Codecov
@@ -68,6 +68,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev]
+        pip install -e .[dev]
     - name: Run engine tests against live servers
       run: pytest tests/test_engines.py tests/test_regressions.py tests/test_written_at.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# a branch with an open PR triggers both push and pull_request runs of the
+# same commit: keep only the newest run per branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,46 +1,67 @@
 name: Test and Coverage
 
+# Run on every push and on every PR. The old filter ['*', '!main'] never
+# matched PRs into main (the branches filter applies to the BASE branch) nor
+# slash-named branches ('*' does not match '/'), so the normal PR flow was
+# never tested.
 on:
   push:
-    branches:
-      - '*'
-      - '!main'
-      - '!master'
+    branches: ['**']
   pull_request:
-    branches:
-      - '*'
-      - '!main'
-      - '!master'
+  workflow_dispatch:
 
 jobs:
-  test-and-coverage:
-    runs-on: ubuntu-latest
-
-    # services:
-    #   redis:
-    #     image: redis
-    #     ports:
-    #       - 6379:6379
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        include:
+          - os: macos-latest
+            python-version: '3.12'
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.12'  # pinned: Python 3.14 + LMDB env-handle issue (#9)
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-        pip install pytest pytest-cov codecov
     - name: Run tests with coverage
-      run: |
-        export PYTHONPATH=$PYTHONPATH:$(pwd)
-        pytest --cov=./ --cov-report=xml
-      env:
-        REDIS_URL: redis://localhost:6379
+      run: pytest --cov=hashstash --cov-report=xml
     - name: Upload results to Codecov
+      if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: quadrismegistus/hashstash
+
+  # server-backed engines (redis, mongo) run against real services on linux
+  test-servers:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+    - name: Run engine tests against live servers
+      run: pytest tests/test_engines.py tests/test_regressions.py tests/test_written_at.py

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ HashStash is a versatile caching library for Python that supports multiple stora
   - [Multiple serializers](#multiple-serializers)
   - [Compression and encoding options](#compression-and-encoding-options)
 - [Installation](#installation)
+- [Security](#security)
 - [Usage](#usage)
   - [Creating a stash](#creating-a-stash)
   - [Stashing objects](#stashing-objects)
@@ -24,6 +25,12 @@ HashStash is a versatile caching library for Python that supports multiple stora
   - [Utilities](#utilities)
     - [Serialization](#serialization)
     - [Encoding and Compression](#encoding-and-compression)
+- [GraphStash](#graphstash)
+  - [Nodes and edges](#nodes-and-edges)
+  - [Multigraph support](#multigraph-support)
+  - [Edge queries](#edge-queries)
+  - [Traversal](#traversal)
+  - [Bulk loading and performance](#bulk-loading-and-performance)
 - [Profiling](#profiling)
   - [Engines](#engines)
   - [Serializers](#serializers)
@@ -55,13 +62,15 @@ HashStash is a versatile caching library for Python that supports multiple stora
     - "__[diskcache](https://pypi.org/project/diskcache/)__" (similar to pairtree, but slower)
     - "__sqlite__" (using [sqlitedict](https://pypi.org/project/sqlitedict/))
     - "__jsonl__" (no dependencies; single human-readable append-only log; best for read-heavy or inspectable caches — see note on concurrent writes below)
+    - "__shelve__" (standard library; simple dbm-backed store)
+    - "__dataframe__" (pairtree layout that stores pandas/polars DataFrames natively as feather/parquet/csv files, requires [pandas](https://pypi.org/project/pandas/))
 
 - Server-based
     - "__redis__" (using [redis-py](https://pypi.org/project/redis/))
     - "__mongo__" (using [pymongo](https://pypi.org/project/pymongo/))
 
 - In-memory
-    - "__memory__" (shared memory, using [ultradict](https://pypi.org/project/ultradict/))
+    - "__memory__" (shared across processes when [ultradict](https://pypi.org/project/ultradict/) is installed; otherwise a process-local dict)
 
 ### Multiple serializers
 
@@ -97,7 +106,7 @@ HashStash requires no dependencies by default, but you can install optional depe
 
 * Default installation (no dependencies): `pip install hashstash`
 
-* Installation with only the recommended/optimal settings (pairtree engine is built-in; adds lz4 compression, pyarrow dataframe serialization, and the ultradict memory engine): `pip install hashstash[rec]`
+* Best performance (lmdb engine + lz4 compression): `pip install hashstash[best]`
 
 * Full installation with all optional dependencies: `pip install hashstash[all]`
 
@@ -106,8 +115,22 @@ HashStash requires no dependencies by default, but you can install optional depe
 For all options see [pyproject.toml](./pyproject.toml) under [project.optional-dependencies].
 
 ```python
-!pip install -qU hashstash[rec]
+!pip install -qU hashstash[best]
 ```
+
+## Security
+
+**Never open a stash you don't trust.** Deserializing a stash executes
+code: the `pickle` serializer is `pickle.loads`, and the default
+`hashstash` serializer can reconstruct functions and classes from stored
+source (via `exec`) and invoke constructors by importable name. A
+malicious value written into a shared cache (a shared Redis/Mongo
+server, a synced or world-writable directory, a downloaded stash file)
+can run arbitrary code on your machine when it is read back.
+
+Treat a stash like you treat a pickle file: only read caches written by
+code you trust, and don't point shared/networked engines at databases
+other parties can write to.
 
 ## Engines & semantics
 
@@ -219,12 +242,14 @@ stash = HashStash()
 # or customize:
 stash = HashStash(
     # naming
-    root_dir="project_stash",    # root directory of the stash (default: default_stash)
-                                 # if not an absolute path, will be ~/.cache/hashstash/[root_dir]
-    dbname="sub_stash",          # name of "database" or subfolder (default: main)
-    
+    root_dir="project_stash",    # bare name -> ~/.cache/hashstash/project_stash;
+                                 # paths ("./cache", "data/cache", "/abs/path", "~/x")
+                                 # resolve like any file path
+    dbname="sub_stash",          # name of "database" or subfolder (default: None)
+
     # engines
-    engine="pairtree",           # or lmdb, sqlite, diskcache, redis, mongo, or memory
+    engine="pairtree",           # or lmdb, sqlite, diskcache, jsonl, shelve,
+                                 # dataframe, redis, mongo, or memory
     serializer="hashstash",      # or jsonpickle or pickle
     compress='lz4',              # or blosc, bz2, gzip, zlib, or raw
     b64=True,                    # base64 encode keys and values
@@ -520,7 +545,7 @@ assert stashed_result7 == stashed_result8 == stashed_result5 == stashed_result6
 
 ↓
 
-    Function results cached in LMDBHashStash(~/.cache/hashstash/functions_stash/lmdb.hashstash.lz4/stashed_result/__main__.expensive_computation/lmdb.hashstash.lz4/data.db)
+    Function results cached in PairtreeHashStash(~/.cache/hashstash/default_stash/pairtree.hashstash.lz4+b64/stashed_result/__main__.expensive_computation/.../data.db)
     
     Stashed key = ((['cat', 'dog'],), {'goodnesses': ['good', 'bad']})
     Called args: (['cat', 'dog'],)
@@ -530,7 +555,7 @@ assert stashed_result7 == stashed_result8 == stashed_result5 == stashed_result6
 
 ### Mapping functions
 
-You can also map functions across many objects, with stashed results, with `stash.map`. By default it uses {num_proc}-2 processors to start computing results in background. In the meantime it returns a `StashMap` object.
+You can also map functions across many objects, with stashed results, with `stash.map`. By default it uses (number of CPUs - 2) processes to start computing results in the background. In the meantime it returns a `StashMap` object. If a mapped function raises, the exception propagates when you read that result.
 
 ```python
 def expensive_computation3(name, goodnesses=['good']):
@@ -822,6 +847,130 @@ data == decoded_data
 
     Mapping __main__.expensive_computation3 across 4 objects [2x]: 6it [00:04,  1.45it/s]               
 
+## GraphStash
+
+GraphStash is a directed property multigraph built on top of HashStash. It stores nodes and edges as key-value pairs in sub-stashes, so every storage engine (pairtree, sqlite, lmdb, etc.) works automatically. It supports multiple edges between the same node pair, Django-style edge queries, BFS traversal, shortest path, and in-memory caching for fast reads.
+
+### Nodes and edges
+
+```python
+from hashstash import HashStash
+
+stash = HashStash(root_dir="my_project")
+g = stash.graph("social")
+
+# Add nodes with properties
+g.add_node("alice", name="Alice", role="engineer")
+g.add_node("bob", name="Bob", role="designer")
+
+# Add directed edges with relationship type and properties
+g.add_edge("alice", "bob", rel="knows", since=2020)
+g.add_edge("alice", "bob", rel="works_with", team="frontend")
+
+# Query
+g.node("alice")                         # → {"name": "Alice", "role": "engineer"}
+g.neighbors("alice")                    # → ["bob"]
+g.neighbors("alice", rel="knows")      # → ["bob"]
+g.neighbors("bob", direction="in")     # → ["alice"]
+g.edge("alice", "bob", rel="knows")    # → {"since": 2020}
+```
+
+Nodes are auto-created when adding edges. `add_edge` auto-creates source and destination nodes with empty properties if they don't already exist.
+
+### Multigraph support
+
+Multiple edges between the same `(src, dst, rel)` are allowed, distinguished by their properties:
+
+```python
+# Per-prompt measurements between model pairs
+g.add_edge("olmo", "olmo-sft", rel="sft_of", prompt="anger", resistance=2.3)
+g.add_edge("olmo", "olmo-sft", rel="sft_of", prompt="fear", resistance=0.5)
+g.add_edge("olmo", "olmo-sft", rel="sft_of", prompt="joy", resistance=1.8)
+
+# Targeted removal by property match
+g.remove_edge("olmo", "olmo-sft", rel="sft_of", prompt="anger")  # removes just that one
+g.remove_edge("olmo", "olmo-sft", rel="sft_of")                  # removes all sft_of edges
+```
+
+### Edge queries
+
+`edges_where` filters edges using Django-style keyword arguments:
+
+```python
+# Filter by relationship type
+g.edges_where(rel="sft_of")
+
+# Filter by edge property with comparison operators
+g.edges_where(resistance__gt=1.0)
+g.edges_where(resistance__gte=0.5, resistance__lt=2.0)
+
+# Combine rel and property filters
+g.edges_where(rel="sft_of", resistance__gt=1.0)
+
+# Filter by source/target node properties
+g.edges_where(source__role="engineer")
+g.edges_where(target__name="Bob")
+
+# String operators on rel
+g.edges_where(rel__startswith="sft")
+```
+
+Supported operators: `__gt`, `__lt`, `__gte`, `__lte`, `__ne`, `__contains`, `__in`, `__startswith`, `__endswith`. No suffix means equality.
+
+### Traversal
+
+```python
+# BFS traversal with depth limit
+levels = g.traverse("alice", depth=2)
+# → {0: ["alice"], 1: ["bob"], 2: ["carol"]}
+
+# Filter traversal by relationship type
+g.traverse("olmo", depth=3, rel="sft_of")
+
+# Shortest path (BFS, unweighted)
+g.shortest_path("alice", "carol")  # → ["alice", "bob", "carol"] or None
+```
+
+### Bulk loading and performance
+
+For large datasets, `add_edges_bulk` groups writes by source node to minimize disk I/O:
+
+```python
+edges = [
+    ("olmo", "olmo-sft", "sft_of", {"prompt": p, "resistance": r})
+    for p, r in zip(prompts, resistances)
+]
+g.add_edges_bulk(edges)
+
+# Warm the in-memory cache for fast subsequent queries
+g.preload()
+
+# Queries now run against cached data (~300x faster)
+g.edges_where(rel="sft_of", resistance__gt=2.0)
+```
+
+GraphStash caches adjacency lists in memory after first read. For write-once-read-many workloads, call `preload()` after bulk loading. Two caveats:
+
+- **Incremental `add_edge` rewrites the node's whole adjacency list per call** — O(degree) I/O per insert, quadratic when building a hub node edge-by-edge. The benchmark numbers below are for `add_edges_bulk`, which groups writes per node; prefer it for any sizeable load.
+- **One writer at a time.** Adjacency updates are read-modify-write over whole lists, and each `stash.graph()` instance caches its reads: two concurrent writers (or a long-lived reader alongside a writer in another process) can lose edges or serve stale results. Use a single writer instance, and create a fresh instance after another process has written.
+
+Benchmarks on Apple M1:
+
+| Edges | Bulk load | Query (cached) |
+|------:|----------:|---------------:|
+| 15K   | 0.3s      | 10ms           |
+| 100K  | 3.3s      | 80–200ms       |
+| 250K  | 8.9s      | 140–300ms      |
+
+Data persists automatically — every write goes to disk through the chosen engine. Reopen the same path later and the graph is there:
+
+```python
+# Later or in another process
+stash = HashStash(root_dir="my_project")
+g = stash.graph("social")
+g.neighbors("alice")  # → ["bob"]
+```
+
 ## Profiling
 
 ### Engines
@@ -860,4 +1009,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ### License
 
-This project is licensed under the GNU License.
+This project is licensed under the GNU General Public License v3.0 (GPLv3) — see [LICENSE](./LICENSE).

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# Coverage is reported, not enforced: informational checks never fail the PR.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/hashstash/__init__.py
+++ b/hashstash/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 from .constants import *
 from .config import *
 from .hashstash import *

--- a/hashstash/config.py
+++ b/hashstash/config.py
@@ -128,19 +128,20 @@ def get_working_engines():
 
 
 def get_engine(engine):
-    from .utils.logs import log
+    # Fail loudly: the old silent fallback to pairtree meant a typo'd engine name
+    # (or a missing dependency) quietly wrote to the wrong store
     if engine is None:
         engine = OPTIMAL_ENGINE_TYPE
     if engine not in get_working_engines():
         if engine in ENGINES:
-            log.debug(
-                f"Engine {engine} is not installed. Defaulting to {DEFAULT_ENGINE_TYPE}. To install {engine}, run: pip install {engine}"
+            hint = ENGINE_INSTALL_HINTS.get(engine, engine)
+            raise ImportError(
+                f"HashStash engine {engine!r} is not installed. "
+                f"Install it with: pip install {hint}"
             )
-        else:
-            log.debug(
-                f'Engine {engine} is not recognized. Defaulting to {DEFAULT_ENGINE_TYPE}. Choose one of: {", ".join(ENGINES)}'
-            )
-        engine = DEFAULT_ENGINE_TYPE
+        raise ValueError(
+            f"Unknown HashStash engine {engine!r}. Choose one of: {', '.join(ENGINES)}"
+        )
     return engine
 
 
@@ -161,7 +162,17 @@ def get_working_serializers():
 def get_serializer_type(serializer):
     if serializer is None:
         serializer = OPTIMAL_SERIALIZER
-    return serializer if serializer in get_working_serializers() else DEFAULT_SERIALIZER
+    if serializer not in get_working_serializers():
+        if serializer in SERIALIZERS:
+            raise ImportError(
+                f"HashStash serializer {serializer!r} is not installed. "
+                f"Install it with: pip install {serializer}"
+            )
+        raise ValueError(
+            f"Unknown HashStash serializer {serializer!r}. "
+            f"Choose one of: {', '.join(SERIALIZERS)}"
+        )
+    return serializer
 
 
 

--- a/hashstash/config.py
+++ b/hashstash/config.py
@@ -1,4 +1,5 @@
 from . import *
+from . import constants as _constants
 
 class Config:
     def __init__(
@@ -7,13 +8,21 @@ class Config:
         engine: ENGINE_TYPES = None,
         compress: bool = None,
         b64: bool = DEFAULT_B64,
-        root_dir: str = DEFAULT_ROOT_DIR,
+        root_dir: str = None,
         **kwargs,
     ):
         self.serializer = get_serializer_type(serializer)
         self.engine = get_engine(engine)
         self.compress = get_compresser(compress)
         self.b64 = b64
+        if root_dir is None:
+            # resolved at call time, not bound at import: HASHSTASH_ROOT_DIR and
+            # patched constants (e.g. test isolation) must take effect for
+            # Config() instances created later
+            root_dir = (
+                os.environ.get("HASHSTASH_ROOT_DIR")
+                or _constants.DEFAULT_ROOT_DIR
+            )
         self.root_dir = root_dir
 
 

--- a/hashstash/config.py
+++ b/hashstash/config.py
@@ -1,3 +1,12 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import List
+from typing import Set
+from typing import Union
+import os
+
 from . import *
 from . import constants as _constants
 

--- a/hashstash/constants.py
+++ b/hashstash/constants.py
@@ -1,5 +1,3 @@
-import warnings
-warnings.filterwarnings('ignore')
 import sys
 import logging
 from typing import *

--- a/hashstash/constants.py
+++ b/hashstash/constants.py
@@ -7,7 +7,10 @@ from typing import Literal
 import time
 import random
 
-DEFAULT_ROOT_DIR = os.path.expanduser("~/.cache/hashstash")
+# HASHSTASH_ROOT_DIR redirects the default cache location (useful in CI/containers)
+DEFAULT_ROOT_DIR = os.environ.get("HASHSTASH_ROOT_DIR") or os.path.expanduser(
+    "~/.cache/hashstash"
+)
 DEFAULT_NAME = "default_stash"
 DEFAULT_PATH = os.path.join(DEFAULT_ROOT_DIR, DEFAULT_NAME)
 DEFAULT_REDIS_DIR = os.path.join(DEFAULT_ROOT_DIR, ".redis")

--- a/hashstash/constants.py
+++ b/hashstash/constants.py
@@ -37,20 +37,30 @@ COMPRESSERS = ['zlib','lz4','blosc','gzip','bz2']
 
 # Cache engines
 ENGINE_TYPES = Literal[
-    "memory", 
-    "pairtree", 
-    # "dataframe",
-    # "shelve",
+    "memory",
+    "pairtree",
+    "dataframe",
+    "shelve",
     "lmdb",
     "sqlite",
-    "diskcache", 
-    "redis", 
+    "diskcache",
+    "redis",
     "mongo",
     "jsonl",
 ]
 ENGINES = ENGINE_TYPES.__args__
-BUILTIN_ENGINES = ['memory', 'pairtree', 'shelve']
+BUILTIN_ENGINES = ['memory', 'pairtree', 'shelve', 'jsonl']
 EXT_ENGINES = [e for e in ENGINES if e not in BUILTIN_ENGINES]
+
+# pip package(s) providing each optional engine, for actionable error messages
+ENGINE_INSTALL_HINTS = {
+    "sqlite": "sqlitedict",
+    "redis": "redis redis_dict",
+    "mongo": "pymongo",
+    "lmdb": "lmdb",
+    "diskcache": "diskcache",
+    "dataframe": "pandas numpy",
+}
 
 # Performance testing constants
 DEFAULT_NUM_PROC = 1# mp.cpu_count() - 2 if mp.cpu_count() > 2 else 1

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -1,3 +1,18 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from collections.abc import MutableMapping
+from functools import cached_property
+from typing import Any
+from typing import List
+from typing import Union
+import importlib
+import json
+import os
+import tempfile
+import uuid
+
 from . import *
 import time
 import threading

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -132,15 +132,17 @@ def _coerce_timestamp(dt):
 
 
 def _unwrap_envelope(decoded):
-    """Return (values, timestamps). Pre-envelope (legacy) entries read as timestamp=0."""
+    """Return (values, timestamps). Pre-envelope (legacy) entries read as timestamp=0.
+
+    A bare (non-envelope) value — including a bare list — is ONE value: treating
+    legacy lists as multiple versions silently corrupted list-valued caches
+    (get() returned the last element instead of the list)."""
     if isinstance(decoded, dict) and decoded.get(ENVELOPE_MARKER) is True:
         values = decoded.get("_values", [])
         timestamps = decoded.get("_written_at", [])
         if len(timestamps) < len(values):
             timestamps = list(timestamps) + [0.0] * (len(values) - len(timestamps))
         return list(values), list(timestamps)
-    if isinstance(decoded, list):
-        return list(decoded), [0.0] * len(decoded)
     return [decoded], [0.0]
 
 
@@ -928,7 +930,10 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def popitem(self):
-        key, value = next(iter(self.items()))
+        try:
+            key, value = next(iter(self.items()))
+        except StopIteration:
+            raise KeyError("popitem(): stash is empty") from None
         del self[key]
         return (key,value)
 
@@ -1239,7 +1244,12 @@ class BaseHashStash(MutableMapping):
         total = 0
         for key in list(self.keys()):
             total += 1
-            entries = self.get_all(key, default=None, with_metadata=True, all_results=True)
+            # as_dataframe/as_list are honored by the dataframe engine (and harmlessly
+            # ignored elsewhere): prune needs plain dicts to read _written_at from
+            entries = self.get_all(
+                key, default=None, with_metadata=True, all_results=True,
+                as_dataframe=False, as_list=True,
+            )
             if not entries:
                 continue
             latest_ts = entries[-1].get("_written_at", 0.0)
@@ -1283,74 +1293,34 @@ def HashStash(
     """
     config = Config()
     engine = get_engine(engine if engine is not None else config.engine)
+    if serializer is not None:
+        serializer = get_serializer_type(serializer)
 
-    if engine == "pairtree":
-        from .pairtree import PairtreeHashStash
+    engine_registry = {
+        "pairtree": ("hashstash.engines.pairtree", "PairtreeHashStash"),
+        "sqlite": ("hashstash.engines.sqlite", "SqliteHashStash"),
+        "sqlitedict": ("hashstash.engines.sqlite", "SqliteHashStash"),
+        "memory": ("hashstash.engines.memory", "MemoryHashStash"),
+        "shelve": ("hashstash.engines.shelve", "ShelveHashStash"),
+        "redis": ("hashstash.engines.redis", "RedisHashStash"),
+        "diskcache": ("hashstash.engines.diskcache", "DiskCacheHashStash"),
+        "lmdb": ("hashstash.engines.lmdb", "LMDBHashStash"),
+        "mongo": ("hashstash.engines.mongo", "MongoHashStash"),
+        "dataframe": ("hashstash.engines.dataframe", "DataFrameHashStash"),
+        "jsonl": ("hashstash.engines.jsonl", "JSONLHashStash"),
+    }
+    module_name, class_name = engine_registry[engine]
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        hint = ENGINE_INSTALL_HINTS.get(engine, engine)
+        raise ImportError(
+            f"HashStash engine {engine!r} failed to import ({e}). "
+            f"Install its dependencies with: pip install {hint}"
+        ) from e
+    cls = getattr(module, class_name)
 
-        cls = PairtreeHashStash
-    elif engine in {"sqlite", "sqlitedict"}:
-        try:
-            from ..engines.sqlite import SqliteHashStash
-
-            cls = SqliteHashStash
-        except ImportError:
-            pass
-    elif engine == "memory":
-        from ..engines.memory import MemoryHashStash
-
-        cls = MemoryHashStash
-    elif engine == "shelve":
-        from ..engines.shelve import ShelveHashStash
-
-        cls = ShelveHashStash
-    elif engine == "redis":
-        try:
-            from ..engines.redis import RedisHashStash
-
-            cls = RedisHashStash
-        except ImportError:
-            pass
-    elif engine == "diskcache":
-        try:
-            from ..engines.diskcache import DiskCacheHashStash
-
-            cls = DiskCacheHashStash
-        except ImportError:
-            pass
-    elif engine == "lmdb":
-        try:
-            from ..engines.lmdb import LMDBHashStash
-
-            cls = LMDBHashStash
-        except ImportError:
-            pass
-    elif engine == "mongo":
-        try:
-            from ..engines.mongo import MongoHashStash
-
-            cls = MongoHashStash
-        except ImportError:
-            pass
-    elif engine == "dataframe":
-        try:
-            from .dataframe import DataFrameHashStash
-
-            cls = DataFrameHashStash
-        except ImportError:
-            pass
-    elif engine == "jsonl":
-        try:
-            from ..engines.jsonl import JSONLHashStash
-
-            cls = JSONLHashStash
-        except ImportError:
-            pass
-    else:
-        raise ValueError(
-            f"\n\nInvalid HashStash engine: {engine}.\n\nOptions available given current install: {', '.join(get_working_engines())}\nAll options: {', '.join(ENGINES)}"
-        )
-
-    object = cls(
+    return cls(
         root_dir=root_dir,
         compress=compress,
         b64=b64,
@@ -1358,7 +1328,6 @@ def HashStash(
         dbname=dbname,
         **kwargs,
     )
-    return object
 
 
 def attach_stash_to_function(func, stash=None, **stash_kwargs):

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -621,7 +621,7 @@ class BaseHashStash(MutableMapping):
         #     "kwargs": kwargs,
         # }
         key = (args,kwargs)
-        return encode_hash(self.serialize(key)) if not store_args else key
+        return encode_hash(self.serialize(key, sort_keys=True)) if not store_args else key
 
     @log.debug
     def new_unencoded_value(
@@ -671,8 +671,10 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def encode_key(self, unencoded_key: Any) -> Union[str, bytes]:
+        # sort_keys: equal dicts (and equal kwargs) must encode to identical bytes
+        # regardless of insertion order, or lookups silently miss
         return self.encode(
-            self.serialize(unencoded_key),
+            self.serialize(unencoded_key, sort_keys=True),
             as_string=self.string_keys,
             # compress=False
         )

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -172,12 +172,16 @@ class BaseHashStash(MutableMapping):
             folders.append(param_folder_name)
             self.path_dirname = os.path.join(*folders)
             self.path = os.path.join(self.path_dirname, self.filename)
+            self._owns_dir = True
         else:
             path = Path(root_dir).expanduser().resolve()
             self.root_dir = str(path.parent)
             self.filename = str(path.name)
             self.path_dirname = str(path.parent)
             self.path = str(path)
+            # path_dirname is a pre-existing directory we share with other files;
+            # clear() must never remove it (see _owns_dir check there)
+            self._owns_dir = False
         
         
         if clear:
@@ -655,6 +659,7 @@ class BaseHashStash(MutableMapping):
                 db[encoded_key] = encoded_value
         except Exception as e:
             log.error(f"Failed to set key {encoded_key}: {e}")
+            raise
 
     @log.debug
     def __contains__(self, unencoded_key: Any) -> bool:
@@ -720,9 +725,12 @@ class BaseHashStash(MutableMapping):
     def clear(self) -> "BaseHashStash":
         for sub in self.children:
             sub.clear()
-        
+
         self.close()
-        self._remove_dir(self.path_dirname)
+        if getattr(self, "_owns_dir", True):
+            self._remove_dir(self.path_dirname)
+        else:
+            self._remove_dir(self.path)
         return self
 
     @log.debug

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -458,7 +458,7 @@ class BaseHashStash(MutableMapping):
         self.set(unencoded_key, unencoded_value)
 
     @log.debug
-    def get_func(self, *args, func=None, _dbname=None, **kwargs):
+    def get_func(self, *args, func=None, _dbname=None, default=None, **kwargs):
         fstash = (
             self.sub_function_results(func, dbname=_dbname)
             if not self.is_function_stash
@@ -468,7 +468,8 @@ class BaseHashStash(MutableMapping):
             self.new_function_key(
                 *args,
                 **kwargs,
-            )
+            ),
+            default=default,
         )
 
     # @log.debug

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -3,14 +3,101 @@ import time
 import threading
 from contextlib import contextmanager
 from datetime import datetime, timezone, timedelta
-from multiprocessing import Manager, Lock as mp_Lock
 from pathlib import Path
 from ..serializers import serialize, deserialize
 
-_manager = None
-_connection_lock = None
 _connection_pool = {}
 _last_used = {}
+_conn_refcount = {}
+_pool_guard = threading.Lock()
+
+_path_locks = {}
+_path_locks_guard = threading.Lock()
+
+if os.name == "nt":
+    import msvcrt
+
+    def _lock_fileno(fileno):
+        # msvcrt.locking(LK_LOCK) retries ~10s then raises; loop until acquired
+        while True:
+            try:
+                msvcrt.locking(fileno, msvcrt.LK_LOCK, 1)
+                return
+            except OSError:
+                continue
+
+    def _unlock_fileno(fileno):
+        msvcrt.locking(fileno, msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _lock_fileno(fileno):
+        fcntl.flock(fileno, fcntl.LOCK_EX)
+
+    def _unlock_fileno(fileno):
+        fcntl.flock(fileno, fcntl.LOCK_UN)
+
+
+class _PathLock:
+    """Reentrant lock scoped to a stash path that actually excludes other
+    processes: a threading.RLock coordinates threads in-process while an
+    advisory file lock (flock/msvcrt on <path>.lock) excludes other processes.
+    The OS releases the file lock automatically if the holder dies."""
+
+    def __init__(self, path):
+        self.lock_path = path + ".lock"
+        self._rlock = threading.RLock()
+        self._file = None
+        self._depth = 0
+
+    def acquire(self):
+        self._rlock.acquire()
+        if self._depth == 0:
+            try:
+                lock_dir = os.path.dirname(self.lock_path)
+                if lock_dir:
+                    os.makedirs(lock_dir, exist_ok=True)
+                self._file = open(self.lock_path, "a+b")
+                _lock_fileno(self._file.fileno())
+            except Exception:
+                if self._file is not None:
+                    self._file.close()
+                    self._file = None
+                self._rlock.release()
+                raise
+        self._depth += 1
+        return True
+
+    def release(self):
+        if self._depth <= 0:
+            raise RuntimeError(f"release of unheld lock {self.lock_path}")
+        self._depth -= 1
+        if self._depth == 0 and self._file is not None:
+            try:
+                if os.name == "nt":
+                    self._file.seek(0)
+                _unlock_fileno(self._file.fileno())
+            finally:
+                self._file.close()
+                self._file = None
+        self._rlock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.release()
+
+
+def get_lock(path):
+    """Process-wide registry of per-path locks (one _PathLock per stash path)."""
+    with _path_locks_guard:
+        lock = _path_locks.get(path)
+        if lock is None:
+            lock = _path_locks[path] = _PathLock(path)
+        return lock
 
 ENVELOPE_MARKER = "__hs_v1__"
 
@@ -78,24 +165,6 @@ def _filter_by_time(values, timestamps, before=None, after=None):
         return [], []
     vs, ts = zip(*kept)
     return list(vs), list(ts)
-
-
-def get_manager():
-    global _manager, _connection_lock
-    if _manager is None:
-        _manager = Manager()
-        _connection_lock = _manager.dict()
-    return _manager
-
-
-# Function to get or create a lock for a given path
-def get_lock(path):
-    global _connection_lock
-    manager = get_manager()
-    if path not in _connection_lock:
-        _connection_lock[path] = manager.Lock()
-    return _connection_lock[path]
-
 
 
 class BaseHashStash(MutableMapping):
@@ -264,7 +333,6 @@ class BaseHashStash(MutableMapping):
         return obj
 
     @property
-    @retry_patiently()
     def db(self):
         return self.get_connection()
 
@@ -274,71 +342,40 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def __enter__(self):
-        if not self.needs_lock:
-            return self
-        
-        log.debug(f"locking {self}")
-        self._lock = get_lock(self.path)
-        try:
-            # Attempt to acquire the lock without blocking
-            acquired = self._lock.acquire(False)
-            if not acquired:
-                log.debug(f"Lock already held for {self}")
-        except TypeError:
-            # If acquire(False) is not supported, fall back to blocking acquire
-            self._lock.acquire()
+        # Blocking, reentrant, cross-process. The old implementation acquired
+        # non-blocking and proceeded into the critical section on failure, and
+        # released other holders' locks on exit — it excluded nothing.
+        if self.needs_lock:
+            get_lock(self.path).acquire()
         return self
 
     @log.debug
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if not self.needs_lock:
-            return
-        if hasattr(self, "_lock"):
-            log.debug(f"unlocking {self}")
-            try:
-                self._lock.release()
-            except (ValueError, RuntimeError) as e:
-                log.debug(e)
-                # Lock was already released or not held
-                pass
+        if self.needs_lock:
+            get_lock(self.path).release()
 
     @contextmanager
-    @retry_patiently()
     def get_connection(self):
-        global _connection_pool, _last_used
-
         if self.needs_reconnect:
             with self.get_db() as db:
                 yield db
-        else:
-            if not self.path in _connection_pool:
+            return
+
+        with _pool_guard:
+            conn = _connection_pool.get(self.path)
+            if conn is None:
                 log.debug(f"Opening {self.engine} at {self.path}")
                 conn = self.get_db()
                 _connection_pool[self.path] = conn
-            else:
-                conn = _connection_pool[self.path]
+            _conn_refcount[self.path] = _conn_refcount.get(self.path, 0) + 1
+            _last_used[self.path] = time.time()
+        try:
+            yield conn
+        finally:
+            with _pool_guard:
+                _conn_refcount[self.path] = _conn_refcount.get(self.path, 1) - 1
                 _last_used[self.path] = time.time()
-            try:
-                yield conn
-            finally:
-                self._cleanup_connections()
-
-    def _cleanup_connections(self):
-        global _connection_pool, _last_used
-        current_time = time.time()
-        for path, last_used in list(_last_used.items()):
-            if current_time - last_used > self.CONNECTION_TIMEOUT:
-                self._close_connection_path(path)
-
-    def close(self):
-        self._close_connection_path(self.path)
-
-    def _close_connection_path(self, path):
-        with self:
-            conn = _connection_pool.pop(path, None)
-            if conn is not None:
-                self._close_connection(conn)
-                _last_used.pop(path, None)
+            self._cleanup_connections()
 
     def connect(self):
         with self.get_connection() as db:
@@ -362,25 +399,30 @@ class BaseHashStash(MutableMapping):
     @classmethod
     def _cleanup_connections(cls):
         current_time = time.time()
-        for path, last_used in list(_last_used.items()):
-            if current_time - last_used > cls.CONNECTION_TIMEOUT:
-                cls._close_connection_path(path)
+        with _pool_guard:
+            stale = [
+                path
+                for path, last_used in _last_used.items()
+                if current_time - last_used > cls.CONNECTION_TIMEOUT
+                and _conn_refcount.get(path, 0) <= 0
+            ]
+        for path in stale:
+            cls._close_connection_path(path)
 
     def close(self):
         self._close_connection_path(self.path)
 
     @classmethod
     def _close_connection_path(cls, path):
-        global _connection_pool
-        conn = _connection_pool.get(path)
+        with _pool_guard:
+            conn = _connection_pool.pop(path, None)
+            _last_used.pop(path, None)
+            _conn_refcount.pop(path, None)
         if conn is not None:
-            with get_lock(path):
-                try:
-                    cls._close_connection(conn)
-                except Exception as e:
-                    log.debug(e)
-                _connection_pool.pop(path, None)
-                _last_used.pop(path, None)
+            try:
+                cls._close_connection(conn)
+            except Exception as e:
+                log.debug(e)
 
     @staticmethod
     def _close_connection(connection):
@@ -510,16 +552,18 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def set(self, unencoded_key: Any, unencoded_value: Any, append=None) -> None:
-        encoded_key = self.encode_key(unencoded_key)
-        # log.info(encoded_key)
-        new_unencoded_value = self.new_unencoded_value(
-            unencoded_value,
-            unencoded_key=unencoded_key,
-            append=append,
-        )
+        # hold the lock across the whole read-modify-write: append mode reads the
+        # old envelope and writes it back, and an unlocked gap loses concurrent appends
+        with self:
+            encoded_key = self.encode_key(unencoded_key)
+            new_unencoded_value = self.new_unencoded_value(
+                unencoded_value,
+                unencoded_key=unencoded_key,
+                append=append,
+            )
 
-        encoded_value = self.encode_value(new_unencoded_value)
-        self._set(encoded_key, encoded_value)
+            encoded_value = self.encode_value(new_unencoded_value)
+            self._set(encoded_key, encoded_value)
 
     @log.debug
     def run(

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -15,6 +15,19 @@ _last_used = {}
 ENVELOPE_MARKER = "__hs_v1__"
 
 
+class _MissingType:
+    """Sentinel distinguishing 'key absent' from a stored None value."""
+
+    def __repr__(self):
+        return "<MISSING>"
+
+    def __bool__(self):
+        return False
+
+
+_MISSING = _MissingType()
+
+
 def _coerce_timestamp(dt):
     """Normalize a datetime or unix timestamp to a float unix timestamp (UTC)."""
     if dt is None:
@@ -109,6 +122,7 @@ class BaseHashStash(MutableMapping):
         "append_mode",
         "is_function_stash",
         "is_tmp",
+        "_root_is_dir",
     ]
     metadata_cols = ["_version", "_written_at"]
     CONNECTION_TIMEOUT = 60  # Close connections after 60 seconds of inactivity
@@ -132,6 +146,7 @@ class BaseHashStash(MutableMapping):
         is_tmp:bool=None,
         append_mode: bool = False,
         clear: bool = False,
+        _root_is_dir: bool = None,
         **kwargs,
     ) -> None:
         config = Config()
@@ -158,13 +173,28 @@ class BaseHashStash(MutableMapping):
 
 
 
-        if root_dir is None or is_dir(root_dir):
+        # _root_is_dir overrides the name-based heuristic: internal callers (sub())
+        # know their root is a directory even when its name contains dots (the
+        # param folder 'engine.serializer.encoding' always does — the old heuristic
+        # silently collapsed every sub-stash onto its parent's directory)
+        root_is_dir = _root_is_dir if _root_is_dir is not None else (
+            root_dir is None or is_dir(root_dir)
+        )
+        self._root_is_dir = root_is_dir
+        if root_is_dir:
             if root_dir is None:
                 self.root_dir = os.path.join(config.root_dir,DEFAULT_NAME)
-            elif not os.path.isabs(root_dir):
-                self.root_dir = os.path.join(config.root_dir, root_dir)
             else:
-                self.root_dir = os.path.expanduser(root_dir)
+                root_dir = str(root_dir)
+                if os.path.isabs(root_dir) or root_dir.startswith("~"):
+                    self.root_dir = os.path.expanduser(root_dir)
+                elif os.sep in root_dir or "/" in root_dir or root_dir.startswith("."):
+                    # a relative *path* (contains separators or leading dot):
+                    # resolve from the current directory, like any file API would
+                    self.root_dir = os.path.abspath(root_dir)
+                else:
+                    # a bare *name*: nest under the configured cache root
+                    self.root_dir = os.path.join(config.root_dir, root_dir)
 
             folders = [self.root_dir]
             if self.dbname: folders.append(self.dbname)
@@ -374,8 +404,8 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def __getitem__(self, unencoded_key: str) -> Any:
-        obj = self.get(unencoded_key)
-        if obj is None:
+        obj = self.get(unencoded_key, default=_MISSING)
+        if obj is _MISSING:
             raise KeyError(unencoded_key)
         return obj
 
@@ -415,17 +445,16 @@ class BaseHashStash(MutableMapping):
         _force=False,
         **kwargs,
     ):
-        unencoded_value = None
+        unencoded_value = _MISSING
         if not _force:
-            unencoded_value = self.get(unencoded_key, default=None, **kwargs)
-        if unencoded_value is None:
+            unencoded_value = self.get(unencoded_key, default=_MISSING, **kwargs)
+        if unencoded_value is _MISSING:
             log.debug("setting")
             unencoded_value = unencoded_value_setter()
-            if unencoded_value is not None:
-                self.set(unencoded_key, unencoded_value)
+            self.set(unencoded_key, unencoded_value)
         else:
             log.debug("getting")
-        return unencoded_value if unencoded_value is not None else default
+        return unencoded_value if unencoded_value is not _MISSING else default
 
     @log.debug
     def get(
@@ -512,31 +541,28 @@ class BaseHashStash(MutableMapping):
         elif get_pytype(func) == "classmethod":
             args = [get_class_from_method(func)] + args
         # func = unwrap_func(func)
+        # underscore-prefixed kwargs are stash-control options: excluded from the
+        # cache key and never passed to the function or to get()
+        func_kwargs = {k: v for k, v in kwargs.items() if k and k[0] != "_"}
         unencoded_key = fstash.new_function_key(
             *args,
             store_args=_store_args,
-            **{k: v for k, v in kwargs.items() if k and k[0] != "_"},
+            **func_kwargs,
         )
-        # #pprint(unencoded_key)
-        # #print('run',meta_kwargs)
         if not _force:
-            res = fstash.get(unencoded_key, default=None, **kwargs)
-            if res is not None:
+            res = fstash.get(unencoded_key, default=_MISSING)
+            if res is not _MISSING:
                 log.debug(
                     f"Stash hit for {func.__name__} in {fstash}. Returning stashed result"
                 )
-                # return unencoded_key
                 return res
 
         # didn't find
         note = "Forced execution" if _force else "Stash miss"
         log.debug(f"{note} for {func.__name__}. Executing function.")
 
-        # call func
-        # args = [obj] + list(args) if obj else list(args)
-        # result = unwrap_func(func)(*args, **kwargs)
         funcx = unwrap_func(func)
-        result = call_function_politely(funcx, *args, **kwargs, _force=_force)
+        result = call_function_politely(funcx, *args, **func_kwargs)
         result = list(result) if is_generator(result) else result
         log.debug(
             f"Caching result for {func.__name__} under {serialize(unencoded_key)}"
@@ -564,7 +590,11 @@ class BaseHashStash(MutableMapping):
     ):
         pmap = None
         self.attach_func(func)
-        key = StashMap.get_stash_key(func, objects, options, total=total)
+        # common_kwargs are merged into every call's options, so they must be part
+        # of the map's identity or maps differing only in kwargs return stale results
+        key = StashMap.get_stash_key(
+            func, objects, options, total=total, **common_kwargs
+        )
         #pprint(key)
         if stash_map and not _force and self.has(key):
             log.info(f"Stash hit for {func.__name__} in {self}. Returning stashed StashMap")
@@ -611,7 +641,11 @@ class BaseHashStash(MutableMapping):
     def attach_func(self, func):
         funcx = unwrap_func(func)
         local_stash = self.sub_function_results(funcx)
-        func.__dict__["stash"] = funcx.__dict__["stash"] = local_stash
+        for f in (func, funcx):
+            try:
+                f.__dict__["stash"] = local_stash
+            except (AttributeError, TypeError):
+                pass  # builtins have no writable __dict__
         return local_stash
 
     @log.debug
@@ -832,8 +866,8 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def setdefault(self, key, default=None):
-        val = self.get(key,default=None)
-        if val is not None: return val
+        val = self.get(key, default=_MISSING)
+        if val is not _MISSING: return val
         self.set(key,default)
         return default
 
@@ -883,12 +917,16 @@ class BaseHashStash(MutableMapping):
     @log.debug
     def sub(self, root_dir:str=None, dbname=DEFAULT_SUB_DBNAME, **kwargs):
         kwargs = {
-            **self.to_dict(), 
-            **kwargs, 
+            **self.to_dict(),
+            **kwargs,
             "parent": self,
             'root_dir': root_dir if root_dir is not None else self.path_dirname,
             'dbname': dbname
         }
+        if root_dir is None:
+            # our own path_dirname is definitionally a directory, even though its
+            # dotted param-folder name would fail the is_dir extension heuristic
+            kwargs['_root_is_dir'] = True
         new_instance = self.__class__(**kwargs)
         self.children.append(new_instance)
         return new_instance
@@ -973,21 +1011,45 @@ class BaseHashStash(MutableMapping):
     def sub_function_results(
         self, func, dbname=None, update_on_src_change=False, **kwargs
     ):
-        # import types
         func_name = get_obj_addr(func).replace("<", "_").replace(">", "_")
-        if update_on_src_change:  # or not can_import_object(func):
-            # logger.info(f'updating on src change because can import object? {can_import_object(func)} --> {func}')
-            func_name += "/" + encode_hash(get_function_src(func))[:10]
-        # new_dbname = f'{self.dbname}/{"stashed_result" if not dbname else dbname}/{func_name}'
+        if update_on_src_change or not self._function_is_stable_identity(func):
+            # closures, lambdas, and non-importable functions can't be identified
+            # by address alone (every lambda is '__main__.<lambda>'; two closures
+            # from one factory share an address): include source + closure values
+            # in the namespace so different functions never share cached results
+            func_name += "/" + encode_hash(self._function_identity_sig(func))[:10]
         new_dbname = f'{"stashed_result" if not dbname else dbname}/{func_name}'
         log.debug(f"Sub-function results stash: {new_dbname}")
         stash = self.sub(
             dbname=new_dbname,
             is_function_stash=True,
         )
-        func.__dict__["stash"] = stash
+        try:
+            func.__dict__["stash"] = stash
+        except (AttributeError, TypeError):
+            pass  # builtins have no writable __dict__
         stash.__dict__["func"] = func
         return stash
+
+    @staticmethod
+    def _function_is_stable_identity(func):
+        """True if the function's import address alone identifies it: importable,
+        not a lambda, and not a closure (whose cell values the address can't see)."""
+        if getattr(func, "__name__", "") == "<lambda>":
+            return False
+        if getattr(unwrap_func(func), "__closure__", None):
+            return False
+        return can_import_object(func)
+
+    @staticmethod
+    def _function_identity_sig(func):
+        from ..serializers.custom import get_function_closure
+
+        sig = get_function_src(func) or getattr(func, "__qualname__", repr(func))
+        closure = get_function_closure(unwrap_func(func))
+        if closure:
+            sig += json.dumps(closure, sort_keys=True, default=str)
+        return sig
 
     def assemble_ld(
         self,

--- a/hashstash/engines/dataframe.py
+++ b/hashstash/engines/dataframe.py
@@ -1,3 +1,10 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import Any
+import os
+
 from . import *
 from .pairtree import PairtreeHashStash
 from .base import _filter_by_time

--- a/hashstash/engines/dataframe.py
+++ b/hashstash/engines/dataframe.py
@@ -1,5 +1,6 @@
 from . import *
 from .pairtree import PairtreeHashStash
+from .base import _filter_by_time
 from ..utils.dataframes import MetaDataFrame
 
 class DataFrameHashStash(PairtreeHashStash):
@@ -15,12 +16,12 @@ class DataFrameHashStash(PairtreeHashStash):
     def to_dict(self):
         return {**super().to_dict(), 'io_engine': self.io_engine, 'df_engine': self.df_engine}
 
-    def set(self, unencoded_key: bytes, unencoded_value: bytes) -> None:
+    def set(self, unencoded_key: Any, unencoded_value: Any, append=None) -> None:
         log.debug(f"Setting value for key: {unencoded_key}")
         # set value as pairtree does if not a dataframe
         if not is_dataframe(unencoded_value):
             log.debug(f"Input is not a DataFrame")
-            return super().set(unencoded_key, unencoded_value)
+            return super().set(unencoded_key, unencoded_value, append=append)
 
         # Handle DataFrame values
         mdf = MetaDataFrame(unencoded_value)
@@ -28,8 +29,14 @@ class DataFrameHashStash(PairtreeHashStash):
 
         encoded_key = self.encode_key(unencoded_key)
         self._set_key(encoded_key)
-        filepath_value = self._get_path_new_value(encoded_key)
-        return mdf.write(filepath_value, io_engine=self.io_engine, compression=self.compress)
+        # the io-engine extension marks this version file as a dataframe; plain
+        # pairtree versions end in '.<pid>' and are routed to the base decoder
+        filepath_value = f"{self._get_path_new_value(encoded_key)}.{self.io_engine}"
+        mdf.write(filepath_value, io_engine=self.io_engine, compression=self.compress)
+        if not (append or self.append_mode):
+            # honor overwrite semantics like pairtree: without this, every set()
+            # accumulated another version file forever
+            self._prune_dir(filepath_value)
 
     @log.debug
     def get_all(
@@ -40,6 +47,8 @@ class DataFrameHashStash(PairtreeHashStash):
         all_results=None,
         as_dataframe=None,
         as_list=None,
+        before=None,
+        after=None,
         **kwargs,
     ) -> Any:
         all_results = self._all_results(all_results)
@@ -50,6 +59,9 @@ class DataFrameHashStash(PairtreeHashStash):
             all_results=self._all_results(all_results),
             with_metadata=True,
         )
+        if before is not None or after is not None:
+            timestamps = [p["_written_at"] for p in paths_ld]
+            paths_ld, _ = _filter_by_time(paths_ld, timestamps, before=before, after=after)
 
         out_l = []
         for path_d in paths_ld:
@@ -114,14 +126,18 @@ class DataFrameHashStash(PairtreeHashStash):
         # return self.serialize(values) if as_string else values
 
     def _decode_value_from_filepath(self, filepath):
-        try:
-            ext = os.path.splitext(filepath)[1]
-            if not ext:
-                return super().decode_value_from_filepath(filepath)
-            return MetaDataFrame.read(filepath, df_engine=self.df_engine, compression=self.compress)
-        except Exception as e:
-            log.debug(f'error reading dataframe from {filepath}: {e}')
-            return None
+        # dataframe version files carry their io-engine as the extension; anything
+        # else is a plain pairtree value. Read errors propagate: returning None
+        # here silently masked corrupted entries.
+        ext = os.path.splitext(filepath)[1].lstrip(".").lower()
+        if ext in get_working_io_engines():
+            return MetaDataFrame.read(
+                filepath,
+                io_engine=ext,
+                df_engine=self.df_engine,
+                compression=self.compress,
+            )
+        return super().decode_value_from_filepath(filepath)
 
     @log.debug
     def items(

--- a/hashstash/engines/diskcache.py
+++ b/hashstash/engines/diskcache.py
@@ -8,4 +8,6 @@ class DiskCacheHashStash(BaseHashStash):
     def get_db(self):
         from diskcache import Cache
         os.makedirs(self.path_dirname, exist_ok=True)
-        return Cache(self.path)
+        # eviction_policy='none' disables diskcache's default 1 GB LRS eviction —
+        # no other engine silently drops entries, so this one must not either
+        return Cache(self.path, eviction_policy="none")

--- a/hashstash/engines/diskcache.py
+++ b/hashstash/engines/diskcache.py
@@ -3,6 +3,7 @@ from . import *
 class DiskCacheHashStash(BaseHashStash):
     engine = 'diskcache'
     string_keys = False
+    needs_lock = False  # diskcache is process- and thread-safe by design
 
     @log.debug
     def get_db(self):

--- a/hashstash/engines/diskcache.py
+++ b/hashstash/engines/diskcache.py
@@ -1,3 +1,9 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+import os
+
 from . import *
 
 class DiskCacheHashStash(BaseHashStash):

--- a/hashstash/engines/jsonl.py
+++ b/hashstash/engines/jsonl.py
@@ -39,7 +39,7 @@ class JSONLHashStash(BaseHashStash):
         self.flat = flat
         super().__init__(*args, compress=compress, b64=b64, **kwargs)
         self._keyset = OrderedSet()
-        self._keyset_loaded = False
+        self._keyset_offset = 0  # bytes of the file already folded into _keyset
         self._flat_meta = frozenset([
             self.key_name, self.value_name, self.delete_name, self.written_at_name
         ])
@@ -79,15 +79,41 @@ class JSONLHashStash(BaseHashStash):
     # --- keyset loading ---
 
     def _ensure_keyset_loaded(self) -> None:
-        if self._keyset_loaded:
+        """Fold any rows appended since the last scan into the keyset.
+
+        Other writers append to the same file, so a one-shot load goes permanently
+        stale; instead we remember how far we've read and incrementally fold new
+        lines on every access (a single getsize() when nothing changed)."""
+        try:
+            size = os.path.getsize(self.path)
+        except OSError:
+            self._keyset = OrderedSet()
+            self._keyset_offset = 0
             return
-        for row in iter_jsonl(self.path):
-            rk = row[self.key_name]
-            ks = self._flat_ks(rk) if self.flat else rk
-            self._keyset.add(ks)
-            if row.get(self.delete_name):
-                self._keyset.discard(ks)
-        self._keyset_loaded = True
+        if size < self._keyset_offset:
+            # file was truncated or replaced (e.g. clear()): rescan from the top
+            self._keyset = OrderedSet()
+            self._keyset_offset = 0
+        if size == self._keyset_offset:
+            return
+        with open(self.path, "r", encoding="utf-8") as f:
+            f.seek(self._keyset_offset)
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    log.warning(f"skipping unparseable JSONL line in {self.path}")
+                    continue
+                rk = row[self.key_name]
+                ks = self._flat_ks(rk) if self.flat else rk
+                if row.get(self.delete_name):
+                    self._keyset.discard(ks)
+                else:
+                    self._keyset.add(ks)
+            self._keyset_offset = f.tell()
 
     # --- get_all ---
 
@@ -133,6 +159,11 @@ class JSONLHashStash(BaseHashStash):
                         values.append(self.decode_value(row[self.value_name]))
                         timestamps.append(row.get(self.written_at_name, 0.0))
 
+        if not self.append_mode:
+            # overwrite semantics: only the last write is "the" value, matching
+            # every other engine (the log retains history but it is not queryable)
+            values, timestamps = values[-1:], timestamps[-1:]
+
         values, timestamps = _filter_by_time(values, timestamps, before=before, after=after)
         if not values:
             return default
@@ -157,14 +188,18 @@ class JSONLHashStash(BaseHashStash):
         with open(self.path, "a", encoding="utf-8") as fh:
             fh.write(line)
 
-    def clear(self) -> None:
+    def clear(self) -> "JSONLHashStash":
+        for sub in self.children:
+            sub.clear()
+        self.close()
         self._keyset = OrderedSet()
-        self._keyset_loaded = False
+        self._keyset_offset = 0
         if os.path.exists(self.path):
             try:
                 os.remove(self.path)
-            except Exception:
-                pass
+            except Exception as e:
+                log.warning(f"could not remove {self.path}: {e}")
+        return self
 
     @log.debug
     def set(self, unencoded_key: Any, unencoded_value: Any, append=None) -> None:
@@ -238,13 +273,15 @@ class JSONLHashStash(BaseHashStash):
     def _values(self):
         for row in iter_jsonl(self.path):
             if not row.get(self.delete_name):
-                yield row[self.value_name]
+                # flat rows have no __value__ field: extract from the row itself
+                yield self._flat_row_to_value(row) if self.flat else row[self.value_name]
 
     @log.debug
     def _items(self):
         for row in iter_jsonl(self.path):
             if not row.get(self.delete_name):
-                yield row[self.key_name], row[self.value_name]
+                value = self._flat_row_to_value(row) if self.flat else row[self.value_name]
+                yield row[self.key_name], value
 
     @log.debug
     def items(self, all_results=None, with_metadata=False, before=None, after=None, **kwargs):
@@ -261,6 +298,8 @@ class JSONLHashStash(BaseHashStash):
         for ks, entries in key2entries.items():
             if not entries:
                 continue
+            if not self.append_mode:
+                entries = entries[-1:]  # overwrite semantics: latest write only
             vals, timestamps, rks = zip(*entries)
             vals, timestamps = _filter_by_time(
                 list(vals), list(timestamps), before=before, after=after

--- a/hashstash/engines/jsonl.py
+++ b/hashstash/engines/jsonl.py
@@ -1,3 +1,12 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import Any
+import json
+import os
+import time
+
 from . import *
 from collections import defaultdict
 from .base import _filter_by_time

--- a/hashstash/engines/lmdb.py
+++ b/hashstash/engines/lmdb.py
@@ -3,6 +3,7 @@ from . import *
 class LMDBHashStash(BaseHashStash):
     engine = 'lmdb'
     filename_is_dir = True
+    needs_lock = False  # LMDB has its own multi-reader/single-writer locking
 
     def __init__(self, *args, map_size=10 * 1024**3, **kwargs):  # Default to 10GB
         self._env = None

--- a/hashstash/engines/lmdb.py
+++ b/hashstash/engines/lmdb.py
@@ -1,3 +1,10 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from contextlib import contextmanager
+import os
+
 from . import *
 import threading
 

--- a/hashstash/engines/lmdb.py
+++ b/hashstash/engines/lmdb.py
@@ -1,24 +1,48 @@
 from . import *
+import threading
+
+# One lmdb.Environment per path per process. Opening the same path twice in one
+# process is unsupported by LMDB ("environment already open", issue #9) — the old
+# per-instance self._env did exactly that whenever two stash objects shared a path.
+_lmdb_envs = {}
+_lmdb_envs_guard = threading.Lock()
+
 
 class LMDBHashStash(BaseHashStash):
     engine = 'lmdb'
     filename_is_dir = True
     needs_lock = False  # LMDB has its own multi-reader/single-writer locking
+    to_dict_attrs = BaseHashStash.to_dict_attrs + ["map_size"]
 
     def __init__(self, *args, map_size=10 * 1024**3, **kwargs):  # Default to 10GB
-        self._env = None
         self.map_size = map_size
         super().__init__(*args, **kwargs)
 
     @log.debug
     def get_db(self):
-        if self._env is None:
-            import lmdb
-            os.makedirs(self.path_dirname, exist_ok=True)
+        with _lmdb_envs_guard:
+            env = _lmdb_envs.get(self.path)
+            if env is None:
+                import lmdb
+                os.makedirs(self.path_dirname, exist_ok=True)
+                env = lmdb.open(self.path, map_size=self.map_size)
+                _lmdb_envs[self.path] = env
+            return env
 
-            self._env = lmdb.open(self.path, map_size=self.map_size)
-        return self._env
+    def _drop_env(self):
+        with _lmdb_envs_guard:
+            env = _lmdb_envs.pop(self.path, None)
+        if env is not None:
+            try:
+                env.close()
+            except Exception as e:
+                log.debug(f"error closing LMDB env: {e}")
 
+    @contextmanager
+    def get_connection(self):
+        # bypass the base connection pool: envs live in _lmdb_envs, and pooling the
+        # same object twice would let pool cleanup close an env the registry still serves
+        yield self.get_db()
 
     @contextmanager
     def get_transaction(self, write=False):
@@ -33,8 +57,7 @@ class LMDBHashStash(BaseHashStash):
                 log.debug(f"LMDB transaction error (attempt {attempt + 1}/{max_retries}): {e}")
                 if attempt == max_retries - 1:
                     raise
-                self.close()  # Close the current environment
-                self._env = None  # Reset the environment to force a new one on next attempt
+                self._drop_env()  # force a fresh environment on the next attempt
 
     def _set(self, encoded_key, encoded_value):
         with self.get_transaction(write=True) as txn:
@@ -91,13 +114,11 @@ class LMDBHashStash(BaseHashStash):
             connection.close()
 
     def clear(self):
+        self._drop_env()
         super().clear()
-        self._env = None  # Reset the environment
         return self
 
     def close(self):
-        if self._env is not None:
-            self._env.close()
-            self._env = None
+        self._drop_env()
         super().close()
 

--- a/hashstash/engines/memory.py
+++ b/hashstash/engines/memory.py
@@ -1,9 +1,5 @@
 from . import *
-from .base import get_manager, BaseHashStash
-from multiprocessing import Manager
-
-# # Use the existing get_manager function
-# manager = Manager()
+from .base import BaseHashStash
 
 SHARED_MEMORY_CACHE = None
 def get_shared_memory_cache():
@@ -16,6 +12,7 @@ def get_shared_memory_cache():
 class MemoryHashStash(BaseHashStash):
     engine = 'memory'
     ensure_dir = False
+    needs_lock = False  # UltraDict provides its own shared-memory locking
 
     @contextmanager
     def get_connection(self):

--- a/hashstash/engines/memory.py
+++ b/hashstash/engines/memory.py
@@ -5,8 +5,17 @@ SHARED_MEMORY_CACHE = None
 def get_shared_memory_cache():
     global SHARED_MEMORY_CACHE
     if SHARED_MEMORY_CACHE is None:
-        from UltraDict import UltraDict
-        SHARED_MEMORY_CACHE = UltraDict(recursive=True)
+        try:
+            from UltraDict import UltraDict
+            SHARED_MEMORY_CACHE = UltraDict(recursive=True)
+        except ImportError:
+            # 'memory' is a builtin engine: without ultradict it degrades to a
+            # process-local dict instead of raising at first use
+            log.debug(
+                "ultradict is not installed; the memory engine is process-local "
+                "(pip install ultradict for shared memory across processes)"
+            )
+            SHARED_MEMORY_CACHE = {}
     return SHARED_MEMORY_CACHE
 
 class MemoryHashStash(BaseHashStash):

--- a/hashstash/engines/memory.py
+++ b/hashstash/engines/memory.py
@@ -1,3 +1,9 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from contextlib import contextmanager
+
 from . import *
 from .base import BaseHashStash
 

--- a/hashstash/engines/mongo.py
+++ b/hashstash/engines/mongo.py
@@ -28,6 +28,7 @@ class MongoHashStash(BaseHashStash):
     string_keys = True
     string_values = True
     dbname = 'hashstash'
+    needs_lock = False  # the server serializes operations; a local file lock can't span hosts anyway
 
     def __init__(self, *args, host=None, port=None, **kwargs):
         if host is not None: self.host = host

--- a/hashstash/engines/mongo.py
+++ b/hashstash/engines/mongo.py
@@ -30,20 +30,25 @@ class MongoHashStash(BaseHashStash):
     dbname = 'hashstash'
     needs_lock = False  # the server serializes operations; a local file lock can't span hosts anyway
 
+    to_dict_attrs = BaseHashStash.to_dict_attrs + ["host", "port"]
+
     def __init__(self, *args, host=None, port=None, **kwargs):
         if host is not None: self.host = host
         if port is not None: self.port = port
-        # force b64 True for mongo
-        self.b64 = True
         super().__init__(*args, **kwargs)
+        # force b64 AFTER super().__init__: assigning before was overwritten by the
+        # base constructor, and b64=False + binary payloads raised UnicodeDecodeError
+        self.b64 = True
 
-        
     @log.debug
     def get_db(self):
         from pymongo import MongoClient
         client = MongoClient(host=self.host, port=self.port)
         db = client[get_db_name(self.dbname)]
-        coll_name = (self.name+'/'+self.dbname).replace('/','.')
+        # include root_dir so stashes constructed with different root_dirs are
+        # isolated, matching file-engine semantics (they used to share all keys)
+        root_sig = encode_hash(str(self.root_dir))[:8]
+        coll_name = f"{self.name}/{self.dbname}/{root_sig}".replace('/', '.')
         coll = db[coll_name]
         coll._client = client
         coll._db = db

--- a/hashstash/engines/mongo.py
+++ b/hashstash/engines/mongo.py
@@ -1,3 +1,10 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import Union
+import os
+
 from . import *
 import hashlib
 import sys

--- a/hashstash/engines/pairtree.py
+++ b/hashstash/engines/pairtree.py
@@ -73,8 +73,12 @@ class PairtreeHashStash(BaseHashStash):
 
     @log.debug
     def _get_path_new_value(self, encoded_key):
+        # the .pid suffix disambiguates concurrent writers hitting the same
+        # microsecond (they used to silently overwrite each other's version);
+        # readers parse the timestamp with splitext, which strips the suffix
         return os.path.join(
-            self._get_path(encoded_key), str(int(time.time() * 1000000))
+            self._get_path(encoded_key),
+            f"{int(time.time() * 1000000)}.{os.getpid()}",
         )
 
     @log.debug
@@ -123,9 +127,15 @@ class PairtreeHashStash(BaseHashStash):
             return f.read()
 
     def _set_to_filepath(self, filepath, encoded_data):
+        # write to a hidden temp file then rename: a crash mid-write must not leave
+        # a truncated version file that poisons every later read of this key
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
-        with open(filepath, "wb") as f:
+        tmp_path = os.path.join(
+            os.path.dirname(filepath), f".tmp.{os.getpid()}.{os.path.basename(filepath)}"
+        )
+        with open(tmp_path, "wb") as f:
             f.write(encoded_data)
+        os.replace(tmp_path, filepath)
 
     @log.debug
     def _set(self, encoded_key: str, encoded_value: Any) -> None:
@@ -143,7 +153,10 @@ class PairtreeHashStash(BaseHashStash):
             if file and file[0]!='.':
                 file_path = os.path.join(dir_path, file)
                 if file_path != filepath_value and os.path.isfile(file_path):
-                    os.remove(file_path)
+                    try:
+                        os.remove(file_path)
+                    except FileNotFoundError:
+                        pass  # concurrent delete/prune already removed it
 
 
         
@@ -182,12 +195,22 @@ class PairtreeHashStash(BaseHashStash):
         )
 
     @staticmethod
-    def _get_path_values_metadata(path_values, incl_path=False):
+    def _parse_written_at(vpath):
+        # filenames are '<micros>[.<pid>][.<io_ext>]': the timestamp is everything
+        # before the first dot
+        name = os.path.basename(vpath)
+        try:
+            return float(name.split(".", 1)[0]) / 1_000_000
+        except ValueError:
+            return 0.0
+
+    @classmethod
+    def _get_path_values_metadata(cls, path_values, incl_path=False):
         return [
             {
                 **({"_path": vpath} if incl_path else {}),
                 "_version": vi + 1,
-                "_written_at": float(os.path.splitext(os.path.basename(vpath))[0]) / 1_000_000,
+                "_written_at": cls._parse_written_at(vpath),
             }
             for vi, vpath in enumerate(path_values)
         ]
@@ -200,12 +223,12 @@ class PairtreeHashStash(BaseHashStash):
             if not self.key_filename in set(files):
                 continue
             key_path = os.path.join(root, self.key_filename)
-            value_paths = [
+            value_paths = sorted(
                 os.path.join(root, file)
                 for file in files
                 if file != self.key_filename
                 and file[0] != "."
-            ]
+            )
             if not value_paths:
                 continue
             if with_metadata:

--- a/hashstash/engines/pairtree.py
+++ b/hashstash/engines/pairtree.py
@@ -230,12 +230,6 @@ class PairtreeHashStash(BaseHashStash):
                 yield self._get_from_filepath(path)
 
     @log.debug
-    # def values(self, all_results=None, **kwargs):
-    #     yield from (
-    #         self.decode_value(value) for value in self._values(all_results=all_results)
-    #     )
-
-    @log.debug
     def _items(self, all_results=None):
         for path_key, path_values in self.paths_items(all_results=all_results):
             encoded_key = self._get_from_filepath(path_key)
@@ -244,31 +238,8 @@ class PairtreeHashStash(BaseHashStash):
                 yield (encoded_key, encoded_value)
 
     @log.debug
-    # def items(self, all_results=None, with_metadata=False, **kwargs):
-    #     for path_key, path_values in self.paths_items(
-    #         all_results=all_results, with_metadata=True
-    #     ):
-    #         encoded_key = self._get_from_filepath(path_key)
-    #         decoded_key = self.decode_key(encoded_key)
-
-    #         for path_value_d in path_values:
-    #             path_value = path_value_d.pop("_path")
-    #             encoded_value = self._get_from_filepath(path_value)
-    #             decoded_value = self.decode_value(encoded_value)
-    #             if not with_metadata:
-    #                 yield (decoded_key, decoded_value)
-    #             else:
-    #                 key = decoded_key
-    #                 value = decoded_value
-    #                 key_d = {"_key": key} if not isinstance(key, dict) else {**key}
-    #                 value_d = {
-    #                     "_value": value
-    #                 }  # if not isinstance(value,dict) else {**value}
-    #                 meta_d = path_value_d
-    #                 yield {**key_d, **meta_d, **value_d}
-
-    def __delitem__(self, unencoded_key: str) -> None:
-        path = self.get_path(unencoded_key)
+    def _del(self, encoded_key: bytes) -> None:
+        path = self._get_path(encoded_key)
         if not os.path.exists(path):
-            raise KeyError(unencoded_key)
+            raise KeyError(encoded_key)
         shutil.rmtree(path, ignore_errors=True)

--- a/hashstash/engines/pairtree.py
+++ b/hashstash/engines/pairtree.py
@@ -1,3 +1,12 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import Any
+import os
+import shutil
+import time
+
 from . import *
 from .base import _filter_by_time
 

--- a/hashstash/engines/redis.py
+++ b/hashstash/engines/redis.py
@@ -23,18 +23,32 @@ class RedisHashStash(BaseHashStash):
     dbname = 'hashstash'
     needs_lock = False  # the server serializes operations; a local file lock can't span hosts anyway
 
+    to_dict_attrs = BaseHashStash.to_dict_attrs + ["host", "port"]
+
     def __init__(self, *args, host=None, port=None, **kwargs):
         if host is not None: self.host = host
         if port is not None: self.port = port
         super().__init__(*args, **kwargs)
-        
+        if not self.b64 and (
+            self.serializer == "pickle"
+            or self.compress not in {False, None, RAW_NO_COMPRESS}
+        ):
+            raise ValueError(
+                "RedisHashStash: b64=False requires a text serializer and no "
+                "compression (values are stored as strings). Pass b64=True."
+            )
+
+    def _namespace(self):
+        # include root_dir so stashes constructed with different root_dirs are
+        # isolated, matching file-engine semantics (they used to share all keys)
+        root_sig = encode_hash(str(self.root_dir))[:8]
+        return f"{self.name}/{self.dbname}/{root_sig}".replace('/', '.')
 
     @log.debug
     def get_db(self):
         from redis_dict import RedisDict
         log.debug(f"Connecting to Redis at {self.host}:{self.port}")
-        name = (self.name+'/'+self.dbname).replace('/','.')
-        return RedisDict(namespace=name, host=self.host, port=self.port, db=get_db_number(self.dbname))
+        return RedisDict(namespace=self._namespace(), host=self.host, port=self.port, db=get_db_number(self.dbname))
     
     @staticmethod
     def _close_connection(connection):

--- a/hashstash/engines/redis.py
+++ b/hashstash/engines/redis.py
@@ -40,16 +40,12 @@ class RedisHashStash(BaseHashStash):
         pass # how does one close a redis connection?
 
     def clear(self):
+        # Delete only this stash's namespaced keys. Never flushdb: the numbered db is
+        # md5(dbname) % 16, so unrelated stashes (and any other application data) share it.
+        log.debug(f"Clearing Redis namespace for {self} at {self.host}:{self.port}")
+        with self.db as db:
+            db.clear()
         super().close()
-        import redis
-        log.debug(f"Dropping Redis database at {self.host}:{self.port}")
-        client = redis.Redis(host=self.host, port=self.port, db=get_db_number(self.dbname))
-        # Free up disk space immediately
-        try:
-            client.flushdb()
-            client.save()
-        except Exception as e:
-            pass
         return self
     
     @property

--- a/hashstash/engines/redis.py
+++ b/hashstash/engines/redis.py
@@ -21,6 +21,7 @@ class RedisHashStash(BaseHashStash):
     string_keys = True
     string_values = True
     dbname = 'hashstash'
+    needs_lock = False  # the server serializes operations; a local file lock can't span hosts anyway
 
     def __init__(self, *args, host=None, port=None, **kwargs):
         if host is not None: self.host = host

--- a/hashstash/engines/redis.py
+++ b/hashstash/engines/redis.py
@@ -1,3 +1,11 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+import os
+import subprocess
+import time
+
 from . import *
 
 import hashlib

--- a/hashstash/engines/shelve.py
+++ b/hashstash/engines/shelve.py
@@ -1,3 +1,9 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+import os
+
 from . import *
 
 class ShelveHashStash(BaseHashStash):

--- a/hashstash/engines/shelve.py
+++ b/hashstash/engines/shelve.py
@@ -11,4 +11,23 @@ class ShelveHashStash(BaseHashStash):
         import shelve
         os.makedirs(self.path_dirname, exist_ok=True)
         return shelve.open(self.path, writeback=writeback)
-    
+
+    # gdbm (the default dbm backend on Linux before Python 3.13) takes an
+    # exclusive lock per open handle. The base generator implementations hold a
+    # handle open while the consuming loop body opens a second one (items() ->
+    # iterate keys -> get_all per key), which gdbm rejects with EAGAIN.
+    # Snapshot under a single handle, then yield with the handle closed.
+    def _keys(self):
+        with self as cache, cache.db as db:
+            keys = list(db.keys())
+        yield from keys
+
+    def _values(self):
+        with self as cache, cache.db as db:
+            values = list(db.values())
+        yield from values
+
+    def _items(self):
+        with self as cache, cache.db as db:
+            items = list(db.items())
+        yield from items

--- a/hashstash/graph.py
+++ b/hashstash/graph.py
@@ -1,5 +1,7 @@
 from collections import defaultdict, deque
 
+_UNSET = object()
+
 _OPS = {
     "eq": lambda a, b: a == b,
     "ne": lambda a, b: a != b,
@@ -12,6 +14,14 @@ _OPS = {
     "startswith": lambda a, b: isinstance(a, str) and a.startswith(b),
     "endswith": lambda a, b: isinstance(a, str) and a.endswith(b),
 }
+
+
+def _safe_op(op, a, b):
+    # one edge storing weight="heavy" must not TypeError every weight__gt query
+    try:
+        return _OPS[op](a, b)
+    except TypeError:
+        return False
 
 
 def _parse_predicate(key):
@@ -41,13 +51,18 @@ def _match(src_props, dst_props, edge_rel, edge_props, predicates):
         elif scope == "target":
             obj = dst_props
         elif field == "rel":
-            if not _OPS[op](edge_rel, value):
+            if not _safe_op(op, edge_rel, value):
                 return False
             continue
         else:
             obj = edge_props
-        actual = obj.get(field) if isinstance(obj, dict) else None
-        if actual is None or not _OPS[op](actual, value):
+        actual = obj.get(field, _UNSET) if isinstance(obj, dict) else _UNSET
+        if actual is _UNSET:
+            # absent property: fails every predicate except __ne (absent != value)
+            if op == "ne":
+                continue
+            return False
+        if not _safe_op(op, actual, value):
             return False
     return True
 
@@ -61,11 +76,24 @@ class GraphStash:
         _in:    node_id -> [(src, rel, {edge_props}), ...]
 
     Multigraph: multiple edges between the same (src, dst, rel) are
-    allowed, distinguished by their properties.
+    allowed, distinguished by their properties. edge() returns the first
+    match; use edges_between() to see all parallel edges.
 
     Read caching: adjacency lists and node props are cached in memory
-    after first read. Writes invalidate affected cache entries. Call
-    preload() after bulk loading to warm the cache for fast queries.
+    after first read; writes update the cache in place. Call preload()
+    after bulk loading to warm the cache for fast queries.
+
+    Concurrency: a GraphStash instance assumes it is the only writer.
+    Adjacency updates are read-modify-write over whole lists, and each
+    instance caches reads — two concurrent writers (or a writer plus a
+    long-lived second instance) can lose edges or serve stale reads.
+    Create one writer instance, and re-create reader instances (or call
+    a fresh stash.graph()) after another process has written.
+
+    Performance: add_edge() rewrites the source and target adjacency
+    lists on every call — O(degree) I/O per insert, quadratic in the
+    final degree when building a hub incrementally. Use add_edges_bulk()
+    for bulk loads; it groups writes per node.
     """
 
     def __init__(self, stash, name="graph"):
@@ -127,6 +155,9 @@ class GraphStash:
             self._get_node_props(nid)
         for nid in self._out_keys():
             self._get_out(nid)
+        # sink nodes (in-edges only) never appear in the out stash: warm their
+        # in-cache from the in stash's own keys
+        for nid in self._in_stash.keys():
             self._get_in(nid)
 
     # -- Nodes --
@@ -134,17 +165,23 @@ class GraphStash:
     def add_node(self, node_id, **props):
         existing = self._get_node_props(node_id)
         if existing is not None:
-            existing.update(props)
-            self._nodes_stash[node_id] = existing
+            merged = {**existing, **props}
         else:
-            self._nodes_stash[node_id] = props
-        self._invalidate(node_id)
+            merged = dict(props)
+        self._nodes_stash[node_id] = merged
+        # update the cache in place: nuking key caches on every write made any
+        # interleaved write/query workload re-list all keys per query
+        self._cache_nodes[node_id] = merged
+        if existing is None and self._cache_node_keys is not None:
+            self._cache_node_keys.append(node_id)
 
     def node(self, node_id):
         props = self._get_node_props(node_id)
         if props is None:
             raise KeyError(node_id)
-        return props
+        # a copy: handing out the cached dict let callers silently diverge the
+        # cache from disk by mutating it
+        return dict(props)
 
     def has_node(self, node_id):
         return self._get_node_props(node_id) is not None
@@ -185,27 +222,42 @@ class GraphStash:
     # -- Edges --
 
     def add_edge(self, src, dst, rel=None, **edge_props):
+        """Add one edge. NOTE: rewrites both nodes' adjacency lists — O(degree)
+        I/O per call. For bulk loading, add_edges_bulk() is much faster."""
         if not self.has_node(src):
             self.add_node(src)
         if not self.has_node(dst):
             self.add_node(dst)
 
         out_list = list(self._get_out(src))
+        had_out = bool(out_list)
         out_list.append((dst, rel, edge_props))
         self._out_stash[src] = out_list
+        self._cache_out[src] = out_list
+        if not had_out and self._cache_out_keys is not None:
+            self._cache_out_keys.append(src)
 
         in_list = list(self._get_in(dst))
         in_list.append((src, rel, edge_props))
         self._in_stash[dst] = in_list
-
-        self._invalidate(src)
-        self._invalidate(dst)
+        self._cache_in[dst] = in_list
 
     def edge(self, src, dst, rel=None):
+        """Return the properties of the FIRST edge matching (src, dst, rel).
+        Parallel edges exist in a multigraph — use edges_between() for all."""
         for d, r, props in self._get_out(src):
             if d == dst and r == rel:
-                return props
+                return dict(props)
         raise KeyError((src, dst, rel))
+
+    def edges_between(self, src, dst, rel=_UNSET):
+        """All parallel edges src -> dst as (rel, props) tuples, optionally
+        restricted to a specific rel (rel=None matches only rel-less edges)."""
+        return [
+            (r, dict(props))
+            for d, r, props in self._get_out(src)
+            if d == dst and (rel is _UNSET or r == rel)
+        ]
 
     def has_edge(self, src, dst, rel=None):
         for d, r, _ in self._get_out(src):
@@ -247,9 +299,9 @@ class GraphStash:
     def edges_of(self, node_id, direction="out"):
         results = []
         if direction in ("out", "both"):
-            results.extend(self._get_out(node_id))
+            results.extend((o, r, dict(p)) for o, r, p in self._get_out(node_id))
         if direction in ("in", "both"):
-            results.extend(self._get_in(node_id))
+            results.extend((o, r, dict(p)) for o, r, p in self._get_in(node_id))
         return results
 
     @property
@@ -257,12 +309,12 @@ class GraphStash:
         result = []
         for src in self._out_keys():
             for dst, rel, props in self._get_out(src):
-                result.append((src, dst, rel, props))
+                result.append((src, dst, rel, dict(props)))
         return result
 
     # -- Query --
 
-    def edges_where(self, rel=None, **kwargs):
+    def edges_where(self, rel=_UNSET, **kwargs):
         """Filter edges by Django-style predicates.
 
         Operators: __gt, __lt, __gte, __lte, __ne, __contains, __in,
@@ -270,9 +322,14 @@ class GraphStash:
         Prefixes: source__ / target__ for node props, rel / rel__op for
                   the relationship string, bare name for edge props.
 
+        rel=None matches only rel-less edges (omit rel to match any).
+        Type-mismatched comparisons (weight__gt=1 against weight='heavy')
+        are non-matches, not errors. An absent property fails every
+        predicate except __ne.
+
         Returns list of (src, dst, rel, props) tuples.
         """
-        if rel is not None:
+        if rel is not _UNSET:
             kwargs["rel"] = rel
         results = []
         for src in self._out_keys():
@@ -282,7 +339,7 @@ class GraphStash:
                     src_props = self._get_node_props(src) or {}
                 dst_props = self._get_node_props(dst) or {}
                 if _match(src_props, dst_props, edge_rel, props, kwargs):
-                    results.append((src, dst, edge_rel, props))
+                    results.append((src, dst, edge_rel, dict(props)))
         return results
 
     def add_edges_bulk(self, edges):
@@ -304,6 +361,7 @@ class GraphStash:
                 if not self.has_node(dst):
                     self.add_node(dst)
                 nodes_seen.add(dst)
+            props = dict(props)  # detach from the caller's dict
             out_new[src].append((dst, rel, props))
             in_new[dst].append((src, rel, props))
 
@@ -311,13 +369,16 @@ class GraphStash:
             out_list = list(self._get_out(src))
             out_list.extend(new_entries)
             self._out_stash[src] = out_list
+            self._cache_out[src] = out_list
 
         for dst, new_entries in in_new.items():
             in_list = list(self._get_in(dst))
             in_list.extend(new_entries)
             self._in_stash[dst] = in_list
+            self._cache_in[dst] = in_list
 
-        self._invalidate()
+        # sources may have gained their first out-edges; relist lazily
+        self._cache_out_keys = None
 
     # -- Neighbors --
 

--- a/hashstash/hashstash.py
+++ b/hashstash/hashstash.py
@@ -3,10 +3,6 @@ from .constants import *
 
 ## standard library
 import multiprocessing as mp
-try:
-    mp.set_start_method('fork')
-except RuntimeError:
-    pass
 from multiprocessing import freeze_support, Manager
 import ast
 import atexit

--- a/hashstash/profilers/engine_profiler.py
+++ b/hashstash/profilers/engine_profiler.py
@@ -132,8 +132,6 @@ class HashStashProfiler:
             tasks = [{**task} for _ in range(iterations)]
             if operations is not None:
                 tasks[-1]['operations'] = [x for x in operations] + ["Size"]
-            print(tasks[0])
-            print(tasks[-1])
 
             smap = profiler_stash.map(
                 profile_stash_transaction,

--- a/hashstash/profilers/engine_profiler.py
+++ b/hashstash/profilers/engine_profiler.py
@@ -1,3 +1,11 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from pathlib import Path
+import time
+import uuid
+
 from . import *
 from ..utils.encodings import encode, decode
 

--- a/hashstash/profilers/profiler.py
+++ b/hashstash/profilers/profiler.py
@@ -1,3 +1,15 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Union
+import random
+import string
+import uuid
+
 from . import *
 
 def generate_primitive():

--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -73,7 +73,12 @@ def _serialize_custom(obj: Any, data:Any=None) -> Any:
     
     if isinstance(obj, type):
         return ClassSerializer.serialize(obj)
-    
+
+    if inspect.ismodule(obj):
+        # serialize modules by reference — recursing into __dict__ would pull in
+        # the world (and blow the recursion limit)
+        return {'__py__': obj.__name__, '__pytype__': 'module'}
+
     if inspect.isgenerator(obj):
         return GeneratorSerializer.serialize(obj)
 
@@ -163,6 +168,9 @@ def _deserialize_custom(data: Any) -> Any:
 
         if pytype == 'generator':
             return GeneratorSerializer.deserialize(data)
+
+        if pytype == 'module':
+            return importlib.import_module(addr)
 
         obj_data = data.get('__data__')
         # 'is not None': an empty-but-valid payload ({}, [], 0, '') must still be

--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -8,27 +8,17 @@ from ..utils.misc import ReusableGenerator
 
 PANDAS_EXTENSION_ACTIVATED = True
 
-def dump_json(obj,as_string=False):
-    try:
-        # res = serialize_orjson(obj)
-        res = serialize_json(obj)
-        log.debug('serialized via orjson')
-        if as_string: res = res.decode('utf-8')
-    except ImportError:
-        res = serialize_json(obj)
-        if not as_string: res = res.encode('utf-8')
-    return res
-    
+# Plain dicts containing any of these keys must round-trip through the tagged
+# '__pytype__: dict' form, or the deserializer would misread them as object markers.
+RESERVED_DICT_KEYS = frozenset({'__py__', '__pytype__', '__data__'})
+
 
 @log.debug
-def serialize_custom(obj: Any) -> str:
+def serialize_custom(obj: Any, sort_keys: bool = False) -> str:
     serialized = _serialize_custom(obj)
-    return json.dumps(serialized)
-
-@log.debug
-def serialize_custom(obj: Any) -> str:
-    serialized = _serialize_custom(obj)
-    return json.dumps(serialized)
+    # sort_keys=True gives canonical bytes: equal dicts (and equal kwargs) always
+    # serialize identically regardless of insertion order. Used for cache keys.
+    return json.dumps(serialized, sort_keys=sort_keys)
 
 def stuff(obj, data=None):
     return _serialize_custom(obj, data=data)
@@ -49,10 +39,19 @@ def _serialize_custom(obj: Any, data:Any=None) -> Any:
 
     if isinstance(obj, (str, int, float, bool)):
         return obj
-    
+
     if isinstance(obj, dict):
-        return {_serialize_custom(k): _serialize_custom(v) for k, v in obj.items()}
-    
+        if all(isinstance(k, str) for k in obj) and not RESERVED_DICT_KEYS & obj.keys():
+            return {k: _serialize_custom(v) for k, v in obj.items()}
+        # Non-string keys (JSON would coerce them to strings) or reserved marker keys:
+        # keep keys as a list of [key, value] pairs so their types survive the round-trip.
+        return {
+            '__pytype__': 'dict',
+            '__items__': [
+                [_serialize_custom(k), _serialize_custom(v)] for k, v in obj.items()
+            ],
+        }
+
     if isinstance(obj, list):
         return [_serialize_custom(v) for v in obj]
 
@@ -140,32 +139,40 @@ def _deserialize_custom(data: Any) -> Any:
     if isinstance(data, dict):
         pytype = data.get('__pytype__')
         addr = data.get('__py__')
-        
+
+        if pytype == 'dict':
+            return {
+                _deserialize_custom(k): _deserialize_custom(v)
+                for k, v in data['__items__']
+            }
+
         if pytype == 'instance':
             return InstanceSerializer.deserialize(data)
-        
+
         if addr and addr in CUSTOM_DESERIALIZERS:
             return CUSTOM_DESERIALIZERS[addr](data)
-        
+
         if pytype == 'reducer':
             return ReducerSerializer.deserialize(data)
-        
+
         if pytype in {'function', 'classmethod', 'instancemethod'}:
             return FunctionSerializer.deserialize(data)
-        
+
         if pytype == 'class':
             return ClassSerializer.deserialize(data)
-        
+
         if pytype == 'generator':
             return GeneratorSerializer.deserialize(data)
 
         obj_data = data.get('__data__')
-        if obj_data and can_import_object(addr):
+        # 'is not None': an empty-but-valid payload ({}, [], 0, '') must still be
+        # reconstructed — the old truthiness check returned the class itself instead
+        if obj_data is not None and addr and can_import_object(addr):
             return _deserialize_object_data(flexible_import(addr), _deserialize_custom(obj_data))
-        
-        if '__py__' in data:
-            return flexible_import(data['__py__'])
-        
+
+        if addr:
+            return flexible_import(addr)
+
         return {_deserialize_custom(k): _deserialize_custom(v) for k, v in data.items()}
     
     return data
@@ -186,9 +193,14 @@ class CustomSerializer:
 class IterableSerializer(CustomSerializer):
     @staticmethod
     def serialize(obj):
+        items = [_serialize_custom(x) for x in obj]
+        if isinstance(obj, (set, frozenset)):
+            # set iteration order depends on PYTHONHASHSEED: sort the serialized
+            # forms so equal sets always produce identical (cache-key-stable) bytes
+            items.sort(key=lambda x: json.dumps(x, sort_keys=True, default=str))
         return {
             '__py__': get_obj_addr(obj),
-            '__data__': [_serialize_custom(x) for x in obj]
+            '__data__': items
         }
 
     @staticmethod
@@ -342,59 +354,69 @@ class PandasSeriesSerializer(CustomSerializer):
 class ReducerSerializer(CustomSerializer):
     @staticmethod
     def serialize(obj):
-        try:
-            reduced = obj.__reduce__()
-            if not isinstance(reduced, tuple) or len(reduced) < 2:
-                raise ValueError("Invalid __reduce__ output")
-            
-            result = {
-                '__py__': get_obj_addr(reduced[0]),
+        # __reduce_ex__(2), not bare __reduce__(): protocol 2 works for C-level types
+        # (complex, datetime, array, ...) and still dispatches to a custom __reduce__.
+        # No fallback — where protocol 2 refuses (locks, sockets), bare __reduce__()
+        # "succeeds" with a copyreg._reconstructor form that cannot deserialize.
+        reduced = obj.__reduce_ex__(2)
+
+        if isinstance(reduced, str):
+            # pickle protocol: a string means "look this name up in the module"
+            return {
                 '__pytype__': 'reducer',
-                '__args__': list(reduced[1]) if reduced[1] else []
+                '__global__': f'{get_obj_module(obj)}.{reduced}',
             }
-            if len(reduced) > 2:
-                result['__state__'] = reduced[2]
-            if len(reduced) > 3:
-                result['__listitems__'] = reduced[3]
-            if len(reduced) > 4:
-                result['__dictitems__'] = reduced[4]
-            if len(reduced) > 5:
-                result['__state_setter__'] = get_obj_addr(reduced[5])
-            return result
-        except Exception as e:
-            log.debug(f"Error using __reduce__ for {type(obj)}: {e}")
-            return None
+        if not isinstance(reduced, tuple) or len(reduced) < 2:
+            raise ValueError(f"Invalid __reduce__ output for {type(obj)}: {reduced!r}")
+
+        # Every component must recurse through _serialize_custom: reduce output
+        # routinely contains bytes/tuples/numpy that raw json.dumps rejects
+        result = {
+            '__py__': get_obj_addr(reduced[0]),
+            '__pytype__': 'reducer',
+            '__args__': [_serialize_custom(a) for a in reduced[1]] if reduced[1] else []
+        }
+        if len(reduced) > 2 and reduced[2] is not None:
+            result['__state__'] = _serialize_custom(reduced[2])
+        if len(reduced) > 3 and reduced[3] is not None:
+            result['__listitems__'] = [_serialize_custom(x) for x in reduced[3]]
+        if len(reduced) > 4 and reduced[4] is not None:
+            result['__dictitems__'] = [
+                [_serialize_custom(k), _serialize_custom(v)] for k, v in reduced[4]
+            ]
+        if len(reduced) > 5 and reduced[5] is not None:
+            result['__state_setter__'] = get_obj_addr(reduced[5])
+        return result
 
     @staticmethod
     def deserialize(data):
-        try:
-            constructor = flexible_import(data['__py__'])
-            args = _deserialize_custom(data['__args__'])
-            state = _deserialize_custom(data.get('__state__'))
-            listitems = _deserialize_custom(data.get('__listitems__'))
-            dictitems = _deserialize_custom(data.get('__dictitems__'))
-            state_setter = flexible_import(data.get('__state_setter__')) if data.get('__state_setter__') else None
+        if data.get('__global__'):
+            return flexible_import(data['__global__'])
 
-            obj = constructor(*args)
+        constructor = flexible_import(data['__py__'])
+        args = _deserialize_custom(data['__args__'])
+        state = _deserialize_custom(data.get('__state__'))
+        listitems = _deserialize_custom(data.get('__listitems__'))
+        dictitems = _deserialize_custom(data.get('__dictitems__'))
+        state_setter = flexible_import(data.get('__state_setter__')) if data.get('__state_setter__') else None
 
-            if state is not None:
-                if state_setter:
-                    state_setter(obj, state)
-                elif hasattr(obj, '__setstate__'):
-                    _invoke_setstate(obj, state)
-                else:
-                    obj.__dict__.update(state)
+        obj = constructor(*args)
 
-            if listitems is not None:
-                obj.extend(listitems)
+        if state is not None:
+            if state_setter:
+                state_setter(obj, state)
+            elif hasattr(obj, '__setstate__'):
+                _invoke_setstate(obj, state)
+            else:
+                obj.__dict__.update(state)
 
-            if dictitems is not None:
-                obj.update(dictitems)
+        if listitems is not None:
+            obj.extend(listitems)
 
-            return obj
-        except Exception as e:
-            log.debug(f"Error using safe_unreduce: {e}")
-            return None
+        if dictitems is not None:
+            obj.update(dictitems)
+
+        return obj
         
 class BytesSerializer(CustomSerializer):
     @staticmethod

--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -1,3 +1,11 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+import importlib
+import inspect
+import types
+
 from . import *
 from ..utils.logs import *
 from pprint import pprint

--- a/hashstash/serializers/jsons.py
+++ b/hashstash/serializers/jsons.py
@@ -1,3 +1,10 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+import json
+import pickle
+
 from . import *
 
 # try:

--- a/hashstash/serializers/serializer.py
+++ b/hashstash/serializers/serializer.py
@@ -20,16 +20,21 @@ def get_deserializer(serializer: SERIALIZER_TYPES = DEFAULT_SERIALIZER):
     return deserializer_dict.get(serializer)
 
 @log.debug
-def serialize(obj, serializer: SERIALIZER_TYPES = None, as_string=False):
+def serialize(obj, serializer: SERIALIZER_TYPES = None, as_string=False, sort_keys=False):
     if serializer is None:
         serializer = Config().serializer
     serializer_func = get_serializer(serializer)
     if serializer_func is None:
         raise ValueError(f"Invalid serializer: {serializer}. Choose one of: {', '.join(repr(x) for x in SERIALIZERS)}")
-    
+
     log.debug(f"Attempting to serialize with {serializer_func.__name__}")
     try:
-        data = serializer_func(obj)
+        # only the custom serializer supports canonical (sorted-key) output;
+        # jsonpickle already sorts and pickle bytes cannot be canonicalized
+        if serializer == "hashstash":
+            data = serializer_func(obj, sort_keys=sort_keys)
+        else:
+            data = serializer_func(obj)
         assert isinstance(data, (bytes, str)), "data should be bytes or string"
         log.debug(f"Serialized data type: {type(data)}")
         log.debug(f"Serialized data: {data}")
@@ -56,7 +61,8 @@ def deserialize(data, serializer: SERIALIZER_TYPES = None):
         raise e
 
 
-def bytesize(obj):
+def bytesize(obj, serializer: SERIALIZER_TYPES = None):
     if isinstance(obj, bytes): return len(obj)
     if isinstance(obj, str): return len(obj.encode())
-    return len(serialize(obj, serializer='pickle'))
+    data = serialize(obj, serializer=serializer)
+    return len(data.encode()) if isinstance(data, str) else len(data)

--- a/hashstash/utils/addrs.py
+++ b/hashstash/utils/addrs.py
@@ -1,3 +1,12 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from collections import Counter
+import importlib
+import inspect
+import types
+
 from . import *
 BUILTIN_DECORATORS = {'property', 'classmethod', 'staticmethod', 'cached_property'}
 

--- a/hashstash/utils/addrs.py
+++ b/hashstash/utils/addrs.py
@@ -3,8 +3,7 @@ BUILTIN_DECORATORS = {'property', 'classmethod', 'staticmethod', 'cached_propert
 
 
 def get_obj_module(obj):
-    if hasattr(obj,'__name__') and obj.__name__ == '<lambda>': 
-        print(obj,obj.__name__)
+    if hasattr(obj,'__name__') and obj.__name__ == '<lambda>':
         return '__main__'
     if hasattr(obj, "__module__"): return obj.__module__
     if hasattr(obj, "__class__"): return get_obj_module(obj.__class__)

--- a/hashstash/utils/addrs.py
+++ b/hashstash/utils/addrs.py
@@ -339,7 +339,15 @@ def is_classmethod(obj):
     
     return False
 def is_instancemethod(obj):
-    return not is_classmethod(obj) and hasattr(obj,'__self__') and obj.__self__ is not None
+    # builtins like len expose __self__ as their *module*, not an instance
+    if isinstance(obj, types.BuiltinFunctionType):
+        return False
+    return (
+        not is_classmethod(obj)
+        and hasattr(obj, '__self__')
+        and obj.__self__ is not None
+        and not inspect.ismodule(obj.__self__)
+    )
 
 def is_method(func):
     """

--- a/hashstash/utils/dataframes.py
+++ b/hashstash/utils/dataframes.py
@@ -572,6 +572,7 @@ def has_index(df):
 
 def reinfer_types(df):
     import pandas as pd
+    import warnings
 
     # Infer types for pandas DataFrame. errors='ignore' was removed from to_numeric/to_datetime
     # in pandas 3.0; catch explicitly to preserve the "leave column alone if conversion fails"
@@ -583,6 +584,10 @@ def reinfer_types(df):
             pass
         if df[column].dtype == "object":
             try:
-                df[column] = pd.to_datetime(df[column])
+                with warnings.catch_warnings():
+                    # per-element format inference is exactly what we're asking
+                    # for here; don't spam every CSV read with the warning
+                    warnings.simplefilter("ignore", UserWarning)
+                    df[column] = pd.to_datetime(df[column])
             except (ValueError, TypeError):
                 pass

--- a/hashstash/utils/dataframes.py
+++ b/hashstash/utils/dataframes.py
@@ -1,3 +1,14 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from base64 import b64decode
+from base64 import b64encode
+from typing import Dict
+from typing import List
+from typing import Union
+import io
+
 from . import *
 
 DEFAULT_COMPRESS = 'gzip'  # Define your default compression method here

--- a/hashstash/utils/encodings.py
+++ b/hashstash/utils/encodings.py
@@ -1,3 +1,9 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import Union
+
 from . import *
 import zlib
 import base64

--- a/hashstash/utils/encodings.py
+++ b/hashstash/utils/encodings.py
@@ -66,8 +66,10 @@ def encode_compressed(data, compress_type=DEFAULT_COMPRESS):
         else:
             raise ValueError(f"Unsupported compression type: {compress_type}")
     except Exception as e:
+        # Never fall back to returning the raw input: the entry would be recorded
+        # as compressed but stored uncompressed, making it unreadable on decode.
         log.error(f"Compression error: {e}")
-        return data
+        raise
 
 def decode_compressed(data, compress_type=DEFAULT_COMPRESS):
     compress_type = get_compresser(compress_type)
@@ -92,15 +94,14 @@ def decode_compressed(data, compress_type=DEFAULT_COMPRESS):
             raise ValueError(f"Unsupported compression type: {compress_type}")
     except Exception as e:
         log.error(f"Decompression error: {e}")
-        raise e
-        return data
+        raise
 
 def encode_b64(data):
     try:
         return base64.b64encode(data)
     except Exception as e:
-        log.debug(f"Base64 encoding error: {e}")
-        return data
+        log.error(f"Base64 encoding error: {e}")
+        raise
 
 def decode_b64(data):
     # Accept either str or bytes; verify input is actually base64 to avoid corrupting plain strings

--- a/hashstash/utils/logs.py
+++ b/hashstash/utils/logs.py
@@ -15,18 +15,27 @@ class ColoredFormatter(logging.Formatter):
     }
 
     def format(self, record):
-        log_fmt = f'{self.COLORS[record.levelname]}%(message)s{self.COLORS["RESET"]}'
+        if self.use_color:
+            log_fmt = f'{self.COLORS[record.levelname]}%(message)s{self.COLORS["RESET"]}'
+        else:
+            log_fmt = '%(message)s'
         formatter = logging.Formatter(log_fmt, datefmt='%Y-%m-%d %H:%M:%S')
         return formatter.format(record)
+
+    def __init__(self, use_color=True):
+        super().__init__()
+        self.use_color = use_color
 
 def setup_logger(name, level=logging.INFO):
     """Function to setup a custom logger with color output."""
     logger = logging.getLogger(name)
     logger.setLevel(level)
 
-    # Console Handler
+    # ANSI colors only when stdout is a real terminal (and NO_COLOR unset):
+    # escape codes used to land verbatim in redirected/host logs
+    use_color = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
     console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setFormatter(ColoredFormatter())
+    console_handler.setFormatter(ColoredFormatter(use_color=use_color))
 
     logger.addHandler(console_handler)
     return logger
@@ -97,25 +106,28 @@ def log_wrapper(_func=None, level=logging.INFO):
         @wraps(func)
         def wrapper(*args, **kwargs):
             global current_depth, last_log_time
-            if level>=logger.level:
+            # decide once: logger.level can change while func runs (e.g. an import
+            # inside the call sets it), and re-evaluating on exit left funcname
+            # unbound and corrupted the depth counter
+            logged = level >= logger.level
+            if logged:
                 funcname,params_str = get_function_call_str_l(func,*args,**kwargs)
                 log_func(f'{funcname}(){"  <<<  "+params_str if params_str else ""}', level=level, incl_frame=False)
                 current_depth += 1
-            
+
             try:
                 result = func(*args, **kwargs)
             except Exception as e:
                 log.error(f"Error in {func.__name__}: {str(e)}")
-                current_depth = 0
-                raise e
+                if logged:
+                    current_depth -= 1
+                raise
 
-            if level>=logger.level:
+            if logged:
                 current_depth -= 1
-                # if result is not None: 
                 if result is not None:
                     resx=repr(result).replace("\n", " ")
                     log_func(f'{funcname}()  >>>  {resx}', level=level, incl_frame=False)
-                # log_func(f'>>> {str(result)[:100]}', level=level)
 
                 if not current_depth:
                     last_log_time = None

--- a/hashstash/utils/logs.py
+++ b/hashstash/utils/logs.py
@@ -1,4 +1,18 @@
-from . import *
+# Explicit imports only: this module is imported mid-way through the package's
+# circular star-import chain (utils/__init__ -> logs -> `from . import *` on the
+# partially-initialized utils package). Whether names like `logging` were
+# already present depended on import ordering — and spawn-mode workers under an
+# editable install + coverage hooks order imports differently, crashing with
+# NameError. Never rely on the package namespace here.
+import inspect
+import logging
+import os
+import sys
+import time
+from contextlib import contextmanager
+from functools import wraps
+
+from ..constants import DEFAULT_LOG_LEVEL
 
 
 ## Logging setup

--- a/hashstash/utils/misc.py
+++ b/hashstash/utils/misc.py
@@ -1,3 +1,11 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+import json
+import os
+import shutil
+
 from . import *
 
 def iter_jsonl(path):

--- a/hashstash/utils/misc.py
+++ b/hashstash/utils/misc.py
@@ -14,6 +14,9 @@ def iter_jsonl(path):
                     try:
                         yield json.loads(line)
                     except Exception:
+                        # a torn/corrupt row loses that version: say so instead of
+                        # silently dropping it
+                        log.warning(f"skipping unparseable JSONL line in {path}")
                         continue
 
 def is_jsonable(obj):

--- a/hashstash/utils/misc.py
+++ b/hashstash/utils/misc.py
@@ -35,6 +35,11 @@ def prune_none_values(data, badkeys=None):
 
 @log.debug
 def is_dir(path):
+    # what exists on disk beats any name-based guess
+    if os.path.isdir(path):
+        return True
+    if os.path.isfile(path):
+        return False
     fn, ext = os.path.splitext(path)
     return not bool(ext)
 

--- a/hashstash/utils/pmap.py
+++ b/hashstash/utils/pmap.py
@@ -1,3 +1,11 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from functools import wraps
+import multiprocessing as mp
+import threading
+
 from . import *
 from collections import UserList
 from threading import Thread, Event

--- a/hashstash/utils/pmap.py
+++ b/hashstash/utils/pmap.py
@@ -32,7 +32,14 @@ def get_global_executor(num_proc):
     with executor_lock:
         executor = executors.get(key)
         if executor is None or getattr(executor, "_broken", False):
-            executor = executors[key] = ProcessPoolExecutor(max_workers=num_proc)
+            # explicit spawn context: on Linux <= 3.13 the default is fork, and
+            # forking a worker while another thread (future callbacks, logging)
+            # holds a lock deadlocks the child — pmap is inherently multi-threaded.
+            # Workers rehydrate functions via stuff/unstuff, so nothing relies on
+            # fork's memory inheritance.
+            executor = executors[key] = ProcessPoolExecutor(
+                max_workers=num_proc, mp_context=mp.get_context("spawn")
+            )
         return executor
 
 def shutdown_global_executors():
@@ -103,7 +110,9 @@ class StashMap(UserList):
             self.progress_bar = progress_bar(total=self.total, desc=self.desc)
 
         self._executor = get_global_executor(num_proc)
-        self._executor_lock = mp.Lock() if num_proc > 1 else None
+        # only threads in THIS process contend on it: a multiprocessing.Lock here
+        # was pointless overhead and another fork-inheritance hazard
+        self._executor_lock = threading.Lock() if num_proc > 1 else None
 
         if _results is None:
             self._results = [

--- a/hashstash/utils/pmap.py
+++ b/hashstash/utils/pmap.py
@@ -24,12 +24,16 @@ executors = {}
 executor_lock = threading.Lock()
 
 def get_global_executor(num_proc):
+    # keyed by (pid, num_proc): a later num_proc used to silently reuse whatever
+    # pool was created first; broken pools (worker OOM/segfault) are replaced
+    # instead of poisoning every future pmap in the process
     global executors
-    pid = os.getpid()
+    key = (os.getpid(), num_proc)
     with executor_lock:
-        if pid not in executors:
-            executors[pid] = ProcessPoolExecutor(max_workers=num_proc)
-        return executors[pid]
+        executor = executors.get(key)
+        if executor is None or getattr(executor, "_broken", False):
+            executor = executors[key] = ProcessPoolExecutor(max_workers=num_proc)
+        return executor
 
 def shutdown_global_executors():
     global executors
@@ -238,10 +242,16 @@ class StashMap(UserList):
         
 
 
+    def preload(self):
+        for res in self._results:
+            res.preload()
+
     def __del__(self):
-        # Do not shutdown the global executor here
-        if self.progress_bar:
-            self.progress_bar.close()
+        # Do not shutdown the global executor here; guard the attribute since
+        # __del__ can run on instances whose __init__ raised early
+        progress_bar = getattr(self, "progress_bar", None)
+        if progress_bar:
+            progress_bar.close()
 
     def __getitem__(self, key):
         if isinstance(key, slice):
@@ -287,6 +297,9 @@ class StashMap(UserList):
 
     @classmethod
     def from_dict(cls, data):
+        # preload/precompute forced off: deserializing a stored map must not spawn
+        # a process pool and submit lookups as a side effect of stash.get().
+        # stash.map() re-preloads explicitly when the caller asks for it.
         pmap = cls(
             data["func"],
             objects=data["objects"],
@@ -297,8 +310,8 @@ class StashMap(UserList):
             progress=data["progress"],
             ordered=data["ordered"],
             stash=data["stash"],
-            preload=data["preload"],
-            precompute=data["precompute"],
+            preload=False,
+            precompute=False,
             _results=data["_results"],
         )
         return pmap
@@ -337,10 +350,6 @@ class StashMapSlice(StashMap):
             if index < self.start or index >= self.stop:
                 raise IndexError("StashMapSlice index out of range")
             return self.pmap._get_single_item(index)
-
-    def __del__(self):
-        self.pmap._executor.shutdown(wait=False)
-        self.pmap._executor = None
 
     def to_dict(self):
         return {
@@ -404,6 +413,7 @@ class StashMapRun:
         self.kwargs = kwargs
         self._pmap_instance = _pmap_instance
         self._result = _result
+        self._error = None
         self._future = None
         self._direct_result = None  # New attribute to store direct results
         self._computed = False
@@ -468,12 +478,26 @@ class StashMapRun:
     def _set_preloaded(self, future_or_result):
         self._preloaded = True
         if isinstance(future_or_result, Future):
-            result = future_or_result.result()
+            try:
+                payload = future_or_result.result()
+            except Exception as e:
+                log.debug(f"preload lookup failed: {e}")
+                payload = ("miss", None)
         else:
-            result = future_or_result
-        if result is not None:
-            self._set_computed(result)
+            payload = future_or_result
+        # _pmap_lookup_item returns ('hit', value) / ('miss', None): a bare
+        # None used to be ambiguous, so cached None results were recomputed
+        if (
+            isinstance(payload, tuple)
+            and len(payload) == 2
+            and payload[0] in ("hit", "miss")
+        ):
+            status, value = payload
+        else:
+            status, value = ("hit", payload)
+        if status == "hit":
             self._needed_computing = False
+            self._set_computed(value)
         else:
             self._needed_computing = True
             self.compute()
@@ -499,8 +523,9 @@ class StashMapRun:
                 try:
                     self._result = future_or_result.result()
                 except Exception as e:
-                    log.error(e)
-                    raise e
+                    # raising here would be swallowed by add_done_callback:
+                    # remember the failure and re-raise when .result is read
+                    self._error = e
             else:
                 self._result = future_or_result
         if self._pmap_instance.progress_bar:
@@ -508,19 +533,22 @@ class StashMapRun:
 
     @cached_property
     def result(self):
+        # worker exceptions propagate to the caller — they used to be logged and
+        # silently converted into a None result, indistinguishable from a real None
+        if self._error is not None:
+            raise self._error
         if self._result is not None:
             return self._result
         if not self._computed:
             if not self._processing_started:
                 self._start_processing()
             if self._future:
-                try:
-                    self._result = self._future.result()
-                except Exception as e:
-                    log.error(e)
+                self._result = self._future.result()
             else:
                 self._result = self._direct_result
             self._computed = True
+        if self._error is not None:
+            raise self._error
         return self._result
 
     def compute(self):
@@ -592,6 +620,7 @@ def _pmap_item(stuffed_item):
 
 def _pmap_lookup_item(stuffed_item):
     from ..serializers import unstuff
+    from ..engines.base import _MISSING
 
     unstuffed_item = unstuff(stuffed_item)  # if num_proc>1 else stuffed_item
     func, args, kwargs = (
@@ -601,7 +630,12 @@ def _pmap_lookup_item(stuffed_item):
     )
     stash = unstuffed_item["stash"]
     if stash is not None:
-        return stash.get_func(*args, func=func,**kwargs)
+        result = stash.get_func(*args, func=func, default=_MISSING, **kwargs)
+        # a status tuple, not a bare value: sentinel identity does not survive
+        # pickling across the process boundary, and a cached None is a hit
+        if result is not _MISSING:
+            return ("hit", result)
+    return ("miss", None)
 
 
 

--- a/hashstash/utils/wrappers.py
+++ b/hashstash/utils/wrappers.py
@@ -51,14 +51,6 @@ class DictContext(UserDict):
     def __exit__(self, exc_type, exc_value, traceback):
         pass  # Nothing happens on close
 
-def get_dict(obj):
-    return {
-        k:getattr(obj,k)
-        for k in dir(obj)
-        if k and k[0]=='_'
-        and not isinstance(getattr(obj,k), dict)
-    }
-
 @log.debug
 def stashed_result(
     _func=None,
@@ -78,20 +70,33 @@ def stashed_result(
         if stash is None:
             stash = HashStash(*stash_args, **stash_kwargs)
 
+        from .addrs import unwrap_func
+
+        def _is_bound_call(obj):
+            # A call is a method call only if obj's class actually carries THIS
+            # decorated function under its name — not merely because obj is some
+            # object with a __dict__ (which misclassified plain first arguments)
+            candidate = getattr(type(obj), func.__name__, None)
+            if candidate is None:
+                return False
+            try:
+                return unwrap_func(candidate) is unwrap_func(func)
+            except Exception:
+                return False
+
         @log.debug
         @wraps(func)
         def wrapper(*args, **kwargs):
-            nonlocal _force, stash, _store_args, func
-            if args and get_pytype(args[0]) in {'class', 'instance'}:
-                self_obj = args[0]
-                func = getattr(self_obj, func.__name__)
+            call_func = func
+            if args and _is_bound_call(args[0]):
+                call_func = getattr(args[0], func.__name__)
                 args = args[1:]
 
             # Extract _force from kwargs if present, otherwise use the default force value
             kwargs.setdefault('_force', _force)
             kwargs.setdefault('_store_args', _store_args)
-            
-            return stash.run(func, *args, **kwargs)
+
+            return stash.run(call_func, *args, **kwargs)
             
         func_stash = stash.attach_func(func)
         wrapper.stash = func_stash

--- a/hashstash/utils/wrappers.py
+++ b/hashstash/utils/wrappers.py
@@ -1,3 +1,16 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from collections import UserDict
+from functools import partial
+from functools import wraps
+from typing import Callable
+from typing import Optional
+import functools
+import random
+import time
+
 from . import *
 from .misc import is_method
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ dynamic = ["version"]
 authors = [
   { name="Dr Ryan Heuser", email="ryan.heuser@gmail.com" },
 ]
-description = "A simple file-based caching system using hash-based file names"
+description = "Serialize and cache anything: a dict-like stash with pluggable storage engines (pairtree, lmdb, sqlite, jsonl, redis, mongo, ...), serializers, and compression"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = []
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
 ]
 
@@ -38,8 +38,8 @@ diskcache = ["diskcache"]
 memory = ["ultradict"]
 
 filebased = [
-  "pandas", "polars", "numpy", "pyarrow","fastparquet", 
-  "sqlitedict", 
+  "pandas", "polars", "numpy", "pyarrow","fastparquet",
+  "sqlitedict",
   "diskcache",
   "lmdb",
   "ultradict",
@@ -51,9 +51,9 @@ engines = [
     "pandas", "polars", "numpy", "pyarrow","fastparquet",
     "lmdb",
     "sqlitedict",
-    "diskcache", 
+    "diskcache",
     "redis", "redis_dict",
-    "mongo",
+    "pymongo",
     "ultradict",
 ]
 dev = [
@@ -61,31 +61,35 @@ dev = [
   "pandas", "polars", "numpy", "pyarrow","fastparquet",
   "lmdb",
   "sqlitedict",
-  "diskcache", 
+  "diskcache",
   "redis", "redis_dict",
-  "mongo",
+  "pymongo",
   "ultradict",
 
   # serializers
   "jsonpickle",# "numpy", "pandas"
   "orjson",
-  
+
+  # compressers
+  "lz4",
+  "blosc",
+
   # utils
-  "tqdm", 
+  "tqdm",
   "plotnine",
   "scikit-misc",
 
   # dev tools
-  "pytest", "pytest-cov", "setuptools-scm", "ipython", 
+  "pytest", "pytest-cov", "setuptools-scm", "ipython",
 ]
 all = [
   # engines
   "pandas", "polars", "numpy", "pyarrow","fastparquet",
   "lmdb",
   "sqlitedict",
-  "diskcache", 
+  "diskcache",
   "redis", "redis_dict",
-  "mongo",
+  "pymongo",
   "ultradict",
 
   # serializers
@@ -95,20 +99,17 @@ all = [
   # Compressers
   "lz4",
   "blosc",
-  
+
   # utils
-  "tqdm", 
+  "tqdm",
   "plotnine",
   "scikit-misc",
 ]
 rec = ["pandas","pyarrow","lz4","ultradict"]
 
 [tool.setuptools]
-packages = {find = {}}
+packages = {find = {include = ["hashstash*"]}}
 
 [tool.pytest.ini_options]
 addopts = "-v"
-testpaths = ["."]
-
-[project.scripts]
-test = "pytest:main"
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,37 @@
-"""Session-scoped fixture: redirect the default hashstash cache away from ~/.cache/hashstash
-so tests that construct HashStash() with no root_dir don't collide on a shared path
-(which breaks LMDB's per-process env-handle tracking). See issue #9."""
+"""Session-scoped fixture: redirect the default hashstash cache away from
+~/.cache/hashstash so tests that construct HashStash() with no root_dir never
+touch (or pollute) the developer's real cache. See issue #9.
+
+Config resolves its root_dir at call time from HASHSTASH_ROOT_DIR /
+constants.DEFAULT_ROOT_DIR, so patching both here is effective for every
+Config() created during the session — including in subprocesses, which
+inherit the environment variable.
+"""
 import os
 import tempfile
+
 import pytest
 
-
-CI = os.environ.get("CI") == "true"
-SKIP_CI_REASON = "Known LMDB env-handle issue on CI — see issue #9"
+_TMPDIR = tempfile.mkdtemp(prefix="hashstash-test-")
+# set before hashstash is imported anywhere so import-time consumers see it too
+os.environ["HASHSTASH_ROOT_DIR"] = _TMPDIR
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _isolate_default_cache():
-    tmpdir = tempfile.mkdtemp(prefix="hashstash-test-")
-    # Patch both the constants module and the live Config singleton if already instantiated.
-    from hashstash import constants, config as _config_mod
+    from hashstash import constants
+
     saved = constants.DEFAULT_ROOT_DIR
     saved_path = constants.DEFAULT_PATH
-    constants.DEFAULT_ROOT_DIR = tmpdir
-    constants.DEFAULT_PATH = os.path.join(tmpdir, constants.DEFAULT_NAME)
-    if hasattr(_config_mod, "Config"):
-        try:
-            _config_mod.Config().set_root_dir(tmpdir)
-        except Exception:
-            pass
+    constants.DEFAULT_ROOT_DIR = _TMPDIR
+    constants.DEFAULT_PATH = os.path.join(_TMPDIR, constants.DEFAULT_NAME)
     yield
     constants.DEFAULT_ROOT_DIR = saved
     constants.DEFAULT_PATH = saved_path
+    os.environ.pop("HASHSTASH_ROOT_DIR", None)
+
+
+@pytest.fixture()
+def isolated_default_root():
+    """The session-wide temporary default cache root."""
+    return _TMPDIR

--- a/tests/test_addrs.py
+++ b/tests/test_addrs.py
@@ -2,19 +2,19 @@ import pytest
 from hashstash import *
 logger.setLevel(logging.CRITICAL+1)
 
-def test_function():
+def sample_function():
     pass
 
-class TestClass:
-    def test_method(self):
+class SampleClass:
+    def sample_method(self):
         pass
 
 @pytest.fixture
 def sample_objects():
     return {
-        'function': test_function,
-        'method': TestClass.test_method,
-        'class': TestClass,
+        'function': sample_function,
+        'method': SampleClass.sample_method,
+        'class': SampleClass,
         'builtin': len,
     }
 
@@ -25,20 +25,20 @@ def test_get_obj_module(sample_objects):
     assert get_obj_module(sample_objects['builtin']) == 'builtins'
 
 def test_get_obj_addr(sample_objects):
-    assert get_obj_addr(sample_objects['function']) == 'test_addrs.test_function'
-    assert get_obj_addr(sample_objects['method']) == 'test_addrs.TestClass.test_method'
-    assert get_obj_addr(sample_objects['class']) == 'test_addrs.TestClass'
+    assert get_obj_addr(sample_objects['function']) == 'test_addrs.sample_function'
+    assert get_obj_addr(sample_objects['method']) == 'test_addrs.SampleClass.sample_method'
+    assert get_obj_addr(sample_objects['class']) == 'test_addrs.SampleClass'
 
 def test_get_obj_name(sample_objects):
-    assert get_obj_name(sample_objects['function']) == 'test_function'
-    assert get_obj_name(sample_objects['method']) == 'test_method'
-    assert get_obj_name(sample_objects['class']) == 'TestClass'
+    assert get_obj_name(sample_objects['function']) == 'sample_function'
+    assert get_obj_name(sample_objects['method']) == 'sample_method'
+    assert get_obj_name(sample_objects['class']) == 'SampleClass'
     assert get_obj_name(sample_objects['builtin']) == 'len'
 
 def test_get_obj_nice_name(sample_objects):
-    assert get_obj_nice_name(sample_objects['function']) == 'test_addrs.test_function'
-    assert get_obj_nice_name(sample_objects['method']) == 'TestClass.test_method'
-    assert get_obj_nice_name(sample_objects['class']) == 'test_addrs.TestClass'
+    assert get_obj_nice_name(sample_objects['function']) == 'test_addrs.sample_function'
+    assert get_obj_nice_name(sample_objects['method']) == 'SampleClass.sample_method'
+    assert get_obj_nice_name(sample_objects['class']) == 'test_addrs.SampleClass'
     assert get_obj_nice_name(sample_objects['builtin']) == 'len'
 
 def test_flexible_import():

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -39,44 +39,6 @@ def test_metadataframe_select_columns(sample_data):
     selected = mdf.select_columns(['A', 'B'])
     assert list(selected.columns) == ['A', 'B']
 
-def test_metadataframe_assign():
-    mdf = MetaDataFrame({'A': [1, 2, 3]})
-    result = mdf.assign(B=lambda x: x['A'] * 2, C=10)
-    assert list(result.columns) == ['A', 'B', 'C']
-    assert result['B'].tolist() == [2, 4, 6]
-    assert result['C'].tolist() == [10, 10, 10]
-
-def test_get_working_io_engines():
-    engines = get_working_io_engines()
-    assert isinstance(engines, set)
-    assert 'csv' in engines
-    assert 'json' in engines
-
-def test_get_working_df_engines():
-    engines = get_working_df_engines()
-    assert isinstance(engines, set)
-    assert 'pandas' in engines
-    assert 'polars' in engines
-
-def test_has_index():
-    df_with_index = pd.DataFrame({'A': [1, 2, 3]}).set_index('A')
-    df_without_index = pd.DataFrame({'A': [1, 2, 3]})
-    
-    assert has_index(df_with_index) == True
-    assert has_index(df_without_index) == False
-
-def test_reset_index():
-    df = pd.DataFrame({'A': [1, 2, 3]}).set_index('A')
-    reset_df = reset_index(df)
-    assert 'A' in reset_df.columns
-    assert has_index(reset_df) == False
-
-def test_set_index():
-    df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c']})
-    indexed_df = set_index(df, index_columns=['A'])
-    assert has_index(indexed_df) == True
-    assert indexed_df.index.name == 'A'
-
 # New tests
 
 def test_metadataframe_getitem(sample_data):
@@ -117,13 +79,6 @@ def test_metadataframe_merge():
     assert list(merged.columns) == ['A', 'B', 'C']
     assert len(merged) == 2
 
-def test_metadataframe_concat():
-    mdf1 = MetaDataFrame({'A': [1, 2], 'B': ['a', 'b']})
-    mdf2 = MetaDataFrame({'A': [3, 4], 'B': ['c', 'd']})
-    concatenated = mdf1.concat(mdf2)
-    assert len(concatenated) == 4
-    assert concatenated['A'].tolist() == [1, 2, 3, 4]
-
 @pytest.mark.parametrize("io_engine", ["csv", "parquet", "json", "feather", "pickle"])
 def test_metadataframe_write_read(sample_data, io_engine):
     mdf = MetaDataFrame(sample_data)
@@ -132,31 +87,6 @@ def test_metadataframe_write_read(sample_data, io_engine):
         read_mdf = MetaDataFrame.read(tmp.name, io_engine=io_engine, compression=RAW_NO_COMPRESS)
         assert list(read_mdf.columns) == list(mdf.columns)
         assert read_mdf.shape == mdf.shape
-
-def test_get_io_engine():
-    assert get_io_engine("csv") == "csv"
-    with pytest.raises(ValueError):
-        get_io_engine("invalid_engine")
-
-def test_check_io_engine():
-    assert check_io_engine("csv") == True
-    assert check_io_engine("invalid_engine") == False
-
-def test_check_df_engine():
-    assert check_df_engine("pandas") == True
-    assert check_df_engine("polars") == True
-    assert check_df_engine("invalid_engine") == False
-
-def test_get_df_engine():
-    assert get_df_engine("pandas") == "pandas"
-    with pytest.raises(ValueError):
-        get_df_engine("invalid_engine")
-
-def test_get_dataframe_engine():
-    pd_df = pd.DataFrame({'A': [1, 2, 3]})
-    pl_df = pl.DataFrame({'A': [1, 2, 3]})
-    assert get_dataframe_engine(pd_df) == "pandas"
-    assert get_dataframe_engine(pl_df) == "polars"
 
 def test_set_index_with_prefix():
     df = pd.DataFrame({'_A': [1, 2, 3], 'B': ['a', 'b', 'c']})

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -37,6 +37,24 @@ def test_compression(default_params):
     encoded_uncompressed = encode(data, b64=False, compress=RAW_NO_COMPRESS)
     assert len(encoded_compressed) < len(encoded_uncompressed)
 
+
+def _working_compressers():
+    from hashstash.config import get_working_compressers
+
+    return sorted(get_working_compressers())
+
+
+@pytest.mark.parametrize("compresser", _working_compressers())
+@pytest.mark.parametrize("b64", [True, False])
+def test_every_compresser_roundtrips(compresser, b64):
+    """Only zlib and raw were ever exercised; lz4/blosc/gzip/bz2 were untested."""
+    data = json.dumps({"payload": "data" * 1000}).encode()
+    encoded = encode(data, b64=b64, compress=compresser)
+    decoded = decode(encoded, b64=b64, compress=compresser)
+    assert decoded == data
+    if compresser != RAW_NO_COMPRESS and not b64:
+        assert len(encoded) < len(data)
+
 def test_as_string(default_params):
     data = json.dumps({"test": "data"})
     encoded = encode(data, as_string=True)

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -28,6 +28,8 @@ except Exception as e:
     MONGO_AVAILABLE = False
     MONGO_SKIP_REASON = f"Mongo server unavailable (Docker required): {e}"
 
+from hashstash.engines.shelve import ShelveHashStash
+
 TEST_CLASSES = [
     PairtreeHashStash,
     SqliteHashStash,
@@ -37,6 +39,7 @@ TEST_CLASSES = [
     LMDBHashStash,
     pytest.param(MongoHashStash, marks=pytest.mark.skipif(not MONGO_AVAILABLE, reason=MONGO_SKIP_REASON)),
     JSONLHashStash,
+    ShelveHashStash,
 ]
 
 
@@ -555,9 +558,11 @@ class TestHashStashFactory:
         assert stash.b64 == False
 
     def test_serializer_parameter(self):
-        serializer = "json"
-        stash = HashStash(serializer=serializer)
-        assert serializer in stash.serializer
+        # unknown serializers raise instead of being silently coerced to the default
+        with pytest.raises(ValueError):
+            HashStash(serializer="not_a_serializer")
+        stash = HashStash(serializer="pickle")
+        assert stash.serializer == "pickle"
 
     def test_root_dir_parameter(self):
         root_dir = "/tmp/test_root"
@@ -565,7 +570,9 @@ class TestHashStashFactory:
         assert stash.root_dir == root_dir
 
     def test_invalid_engine(self):
-        assert HashStash(engine="invalid_engine").engine == DEFAULT_ENGINE_TYPE
+        # a typo'd engine used to silently fall back to pairtree, writing to the wrong store
+        with pytest.raises(ValueError):
+            HashStash(engine="invalid_engine")
 
     def test_default_parameters(self):
         config = Config()

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -12,21 +12,30 @@ from hashstash.engines.jsonl import JSONLHashStash
 # logger.setLevel(logging.DEBUG)
 logger.setLevel(logging.CRITICAL+1)
 
+# Plain connectivity probes: importing a test module must never shell out to
+# docker or start containers. CI provides these servers via services;
+# developers run their own (e.g. `docker run -d -p 6379:6379 redis`).
 try:
-    start_redis_server()
+    import redis as _redis
+
+    _redis.Redis(host="localhost", port=6379, socket_connect_timeout=1).ping()
     REDIS_AVAILABLE = True
     REDIS_SKIP_REASON = ""
 except Exception as e:
     REDIS_AVAILABLE = False
-    REDIS_SKIP_REASON = f"Redis server unavailable (Docker required): {e}"
+    REDIS_SKIP_REASON = f"No Redis server on localhost:6379: {e}"
 
 try:
-    start_mongo_server()
+    from pymongo import MongoClient as _MongoClient
+
+    _MongoClient(
+        host="localhost", port=27017, serverSelectionTimeoutMS=1000
+    ).server_info()
     MONGO_AVAILABLE = True
     MONGO_SKIP_REASON = ""
 except Exception as e:
     MONGO_AVAILABLE = False
-    MONGO_SKIP_REASON = f"Mongo server unavailable (Docker required): {e}"
+    MONGO_SKIP_REASON = f"No MongoDB server on localhost:27017: {e}"
 
 from hashstash.engines.shelve import ShelveHashStash
 
@@ -83,11 +92,9 @@ class TestHashStash:
         if isinstance(cache, ShelveHashStash):
             time.sleep(0.1)  # Add a small delay to ensure data is written
 
-        cached_size = self._get_cached_size(cache, "large_data")
-        assert cached_size < raw_size
-
-        compression_ratio = cached_size / raw_size
-        #print(f"Compression ratio ({type(cache).__name__}): {compression_ratio:.2%}")
+        if self._compression_active(cache):
+            cached_size = self._get_cached_size(cache, "large_data")
+            assert cached_size < raw_size
 
         retrieved_data = cache["large_data"]
         assert retrieved_data == large_data
@@ -118,17 +125,18 @@ class TestHashStash:
         if isinstance(cache, ShelveHashStash):
             time.sleep(0.1)  # Add a small delay to ensure data is written
 
-        cached_size = self._get_cached_size(cache, "test_data")
-        assert cached_size < raw_size
+        if self._compression_active(cache):
+            cached_size = self._get_cached_size(cache, "test_data")
+            assert cached_size < raw_size
 
         retrieved_data = cache["test_data"]
         assert retrieved_data == test_data
 
     def test_very_large_data_compression(self, cache):
+        # a two-symbol alphabet keeps the payload compressible: fully random
+        # text has no redundancy, so asserting compression on it must fail
         very_large_data = {
-            "large_string": "".join(
-                random.choices("abcdefghijklmnopqrstuvwxyz", k=1_000_000)
-            ),
+            "large_string": "".join(random.choices("ab", k=1_000_000)),
             "large_list": [random.randint(1, 1000000) for _ in range(1000)],
             "large_nested": {
                 f"key_{i}": {
@@ -147,15 +155,9 @@ class TestHashStash:
         if isinstance(cache, ShelveHashStash):
             time.sleep(0.1)  # Add a small delay to ensure data is written
 
-        cached_size = self._get_cached_size(cache, "very_large_data")
-        assert cached_size < raw_size
-
-        compression_ratio = cached_size / raw_size
-        #print(f"Very large data compression ({type(cache).__name__}):")
-        #print(f"Raw size: {raw_size / 1024 / 1024:.2f} MB")
-        #print(f"Cached size: {cached_size / 1024 / 1024:.2f} MB")
-        #print(f"Compression ratio: {compression_ratio:.2%}")
-        #print(f"Space saved: {(raw_size - cached_size) / 1024 / 1024:.2f} MB")
+        if self._compression_active(cache):
+            cached_size = self._get_cached_size(cache, "very_large_data")
+            assert cached_size < raw_size
 
         retrieved_data = cache["very_large_data"]
         assert retrieved_data == very_large_data
@@ -214,15 +216,6 @@ class TestHashStash:
         assert len(items) == 2
         assert ("key1", "value1") in items
         assert ("key2", "value2") in items
-
-    def test_sub_function_results(self, cache):
-        def example_func(x, y):
-            return x + y
-
-        sub_stash = cache.sub_function_results(example_func)
-        assert isinstance(sub_stash, BaseHashStash)
-        assert "stashed_result" in sub_stash.dbname
-        assert "example_func" in sub_stash.dbname
 
     def test_assemble_ld(self, cache):
         #print(len(cache))
@@ -428,8 +421,6 @@ class TestHashStash:
         assert len(hashed) == 32  # MD5 hash length
 
     def test_stashed_result(self, cache):
-        if os.environ.get("CI") == "true" and isinstance(cache, LMDBHashStash):
-            pytest.skip("Known LMDB env-handle issue on CI — see issue #9")
         @cache.stashed_result
         def test_func(x):
             return x * 2
@@ -455,7 +446,16 @@ class TestHashStash:
 
     @staticmethod
     def _get_cached_size(cache, key):
-        return len(cache[key])
+        """Bytes of the encoded (serialized+compressed+b64) stored value.
+        The old version measured len() of the DECODED object — comparing a
+        dict's key count against a byte length, which asserted nothing."""
+        value = cache[key]
+        encoded = cache.encode_value(cache.new_unencoded_value(value, unencoded_key=key))
+        return len(encoded.encode()) if isinstance(encoded, str) else len(encoded)
+
+    @staticmethod
+    def _compression_active(cache):
+        return cache.compress not in {False, None, RAW_NO_COMPRESS}
 
     def test_append_mode(self, cache):
         cache.append_mode = True

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -42,24 +42,21 @@ def test_pmap_mismatched_lengths():
     with pytest.raises(ValueError):
         list(pmap(square, objects=[1, 2, 3], options=[{}, {}]))
 
-def slow_square(x):
-    time.sleep(1)
-    return x * x
-
-def test_pmap_keyboard_interrupt():
-    with pytest.raises(KeyboardInterrupt):
-        result = pmap(slow_square, objects=[1, 2, 3, 4], num_proc=2)
-        next(result)  # Start the generator
-        raise KeyboardInterrupt()
-
 def failing_function(x):
     if x == 2:
         raise ValueError("Simulated error")
     return x * x
 
-def test_pmap_exception_handling():
-    res = list(pmap(failing_function, objects=[1, 2, 3, 4], num_proc=2))
-    assert None in res
+def test_pmap_exception_propagates():
+    """Worker exceptions used to be silently converted into None results."""
+    with pytest.raises(ValueError, match="Simulated error"):
+        list(pmap(failing_function, objects=[1, 2, 3, 4], num_proc=2))
+
+def test_pmap_pool_usable_after_worker_exception():
+    """A failed worker must not poison later pmap calls in the process."""
+    with pytest.raises(ValueError):
+        list(pmap(failing_function, objects=[2], num_proc=2))
+    assert list(pmap(square, objects=[3], num_proc=2)) == [9]
 
 @pytest.fixture
 def mock_log_prefix_str():
@@ -84,44 +81,19 @@ def test_progress_bar_tqdm_not_available(mock_log_prefix_str):
         
         assert result == list(test_iter)
 
-def test_progress_bar_current_depth(mock_log_prefix_str):
-    with patch('hashstash.utils.pmap.tqdm', create=True) as mock_tqdm:
-        from hashstash.utils.pmap import current_depth, progress_bar
-        
-        initial_depth = current_depth
-        test_iter = range(5)
-        mock_tqdm.return_value = MagicMock(__iter__=lambda self: iter(test_iter))
-        
-        list(progress_bar(test_iter, progress=True))
-        
-        assert current_depth == initial_depth
-
-def square(x):
-    return x ** 2
-
-
-@patch('concurrent.futures.ProcessPoolExecutor')
-def test_pmap_multi_process(mock_executor):
-    mock_future = MagicMock()
-    mock_future.result.side_effect = [i**2 for i in range(5)]
-    mock_submit = MagicMock(return_value=mock_future)
-    mock_executor.return_value.__enter__.return_value.submit = mock_submit
-    
+def test_pmap_multi_process():
     result = list(pmap(square, objects=range(5), num_proc=2, progress=False, ordered=True))
     assert result == [0, 1, 4, 9, 16]
 
-def test_pmap_single_process():
-    def square(x):
-        return x ** 2
-    
+def test_pmap_single_process_range():
     result = list(pmap(square, objects=range(5), num_proc=1, progress=False))
     assert result == [0, 1, 4, 9, 16]
 
-def test_pmap_with_options():
-    def power(x, n):
-        return x ** n
-    
-    result = list(pmap(power, objects=[2, 3, 4], options=[{'n': 2}, {'n': 3}, {'n': 2}], num_proc=1, progress=False))
+def _power(x, n):
+    return x ** n
+
+def test_pmap_with_option_dicts():
+    result = list(pmap(_power, objects=[2, 3, 4], options=[{'n': 2}, {'n': 3}, {'n': 2}], num_proc=1, progress=False))
     assert result == [4, 27, 16]
 
 def test_pmap_error_handling():

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -9,8 +9,6 @@ from hashstash.engines.base import HashStash
 from hashstash.serializers.serializer import serialize, deserialize
 logger.setLevel(logging.CRITICAL+1)
 
-_CI = os.environ.get("CI") == "true"
-_SKIP_CI = "Known LMDB env-handle issue on CI — see issue #9"
 
 def square(x):
     return x * x
@@ -103,7 +101,6 @@ def test_pmap_error_handling():
     with pytest.raises(ValueError):
         list(pmap(lambda x: x, objects=[1, 2], options=[{}]))
 
-@pytest.mark.skipif(_CI, reason=_SKIP_CI)
 def test_pmap_with_stash():
     with HashStash().tmp() as stash:
         result = list(pmap(square, objects=[1, 2, 3], num_proc=1, stash=stash, progress=False))
@@ -129,7 +126,6 @@ def test_pmap_item_without_stash():
     result = _pmap_item(item)
     assert result == 9
 
-@pytest.mark.skipif(_CI, reason=_SKIP_CI)
 def test_pmap_item_with_stash():
     with HashStash().tmp() as stash:
         

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -6,8 +6,6 @@ import pytest
 import numpy as np
 import pandas as pd
 
-_CI = os.environ.get("CI") == "true"
-_SKIP_CI = "Known LMDB env-handle issue on CI — see issue #9"
 
 def test_generate_primitive():
     result = generate_primitive()
@@ -39,7 +37,6 @@ def test_generate_data_dataframe():
     assert 'id' in result.columns
     assert all(col.startswith(('int_', 'float_', 'str_', 'bool_')) for col in result.columns if col != 'id')
 
-@pytest.mark.skipif(_CI, reason=_SKIP_CI)
 def test_generate_dict():
     result = generate_dict(1000)
     assert isinstance(result, dict)

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -1,4 +1,8 @@
-import sys; sys.path.append('..')
+# NOTE: never sys.path.append('..') here. The relative '..' entry is inherited
+# by multiprocessing spawn workers, where it can resolve a sibling directory
+# named 'hashstash' (e.g. /home/runner/work/hashstash/<repo>) as an empty
+# namespace package that shadows the real one — every submodule then imports
+# from an empty parent and crashes with NameErrors (broke CI on Linux <=3.11).
 import os
 from hashstash.profilers import *
 logger.setLevel(logging.CRITICAL+1)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -354,6 +354,109 @@ def test_bare_name_nests_under_config_root():
     assert stash.root_dir == os.path.join(Config().root_dir, "bare_name_regression")
 
 
+# --- Stage 4: real locking & connection pool --------------------------------
+
+
+def test_lock_is_reentrant(tmp_path):
+    """Nested `with stash:` used to make the inner exit release the outer lock."""
+    pytest.importorskip("sqlitedict")
+    stash = HashStash(engine="sqlite", root_dir=str(tmp_path / "cache"))
+    with stash:
+        with stash:
+            stash["k"] = 1
+        stash["k2"] = 2  # still holding the outer lock
+    assert stash["k"] == 1
+    assert stash["k2"] == 2
+
+
+@pytest.mark.skipif(os.name == "nt", reason="flock check is POSIX-only")
+def test_lock_excludes_other_processes(tmp_path):
+    """The old Manager-based lock was per-process: two independent processes never
+    shared it. The file lock must actually be held across process boundaries."""
+    pytest.importorskip("sqlitedict")
+    stash = HashStash(engine="sqlite", root_dir=str(tmp_path / "cache"))
+    stash["seed"] = 1  # create dirs + lock file
+    lock_path = stash.path + ".lock"
+
+    probe = (
+        "import fcntl, sys\n"
+        f"f = open({lock_path!r}, 'a+b')\n"
+        "try:\n"
+        "    fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+        "    print('ACQUIRED')\n"
+        "except OSError:\n"
+        "    print('LOCKED')\n"
+    )
+    with stash:
+        held = subprocess.run(
+            [sys.executable, "-c", probe], capture_output=True, text=True
+        )
+    released = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True
+    )
+    assert held.stdout.strip() == "LOCKED", held.stderr
+    assert released.stdout.strip() == "ACQUIRED", released.stderr
+
+
+def test_concurrent_appends_no_lost_updates(tmp_path):
+    """Append-mode was an unlocked read-modify-write: concurrent appenders read
+    the same old envelope and one append vanished."""
+    pytest.importorskip("sqlitedict")
+    root = str(tmp_path / "cache")
+    n_procs, n_appends = 4, 5
+
+    worker = (
+        "import sys\n"
+        f"sys.path.insert(0, {REPO_ROOT!r})\n"
+        "from hashstash import HashStash\n"
+        f"stash = HashStash(engine='sqlite', root_dir={root!r}, append_mode=True)\n"
+        f"for i in range({n_appends}):\n"
+        "    stash.set('k', (int(sys.argv[1]), i))\n"
+    )
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", worker, str(n)],
+            env={**os.environ, "PYTHONPATH": REPO_ROOT},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        for n in range(n_procs)
+    ]
+    for p in procs:
+        _, err = p.communicate(timeout=120)
+        assert p.returncode == 0, err.decode()
+
+    stash = HashStash(engine="sqlite", root_dir=root, append_mode=True)
+    versions = stash.get_all("k")
+    assert len(versions) == n_procs * n_appends
+
+
+def test_connection_pool_thread_safety(tmp_path):
+    """The pool was an unsynchronized dict: concurrent threads could clobber and
+    leak each other's connections."""
+    import threading
+
+    pytest.importorskip("sqlitedict")
+    stash = HashStash(engine="sqlite", root_dir=str(tmp_path / "cache"))
+    errors = []
+
+    def work(tid):
+        try:
+            for i in range(20):
+                stash[f"{tid}-{i}"] = i
+                assert stash[f"{tid}-{i}"] == i
+        except Exception as e:  # pragma: no cover - failure path
+            errors.append(e)
+
+    threads = [threading.Thread(target=work, args=(t,)) for t in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors
+    assert len(stash) == 8 * 20
+
+
 @pytest.mark.skipif(not _redis_available(), reason="no local redis server")
 def test_redis_clear_scoped_to_namespace():
     """clear() used to flushdb() the whole numbered Redis db, wiping other stashes

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -230,6 +230,130 @@ def test_unserializable_object_raises_not_none():
         serialize(threading.Lock(), serializer="hashstash")
 
 
+# --- Stage 3: None-sentinel, function identity, wrappers/run() --------------
+
+
+def test_stored_none_is_not_a_miss(tmp_path):
+    """Storing None used to make __getitem__ raise KeyError and get_set re-run
+    its setter on every call."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    stash["k"] = None
+    assert "k" in stash
+    assert stash["k"] is None
+
+    calls = []
+
+    def setter():
+        calls.append(1)
+        return None
+
+    assert stash.get_set("none-key", setter) is None
+    assert stash.get_set("none-key", setter) is None
+    assert len(calls) == 1
+
+
+def _returns_none(x):
+    _returns_none.calls.append(x)
+    return None
+
+
+_returns_none.calls = []
+
+
+def test_none_returning_function_cached(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    assert stash.run(_returns_none, 1) is None
+    assert stash.run(_returns_none, 1) is None
+    assert len(_returns_none.calls) == 1
+
+
+def test_closures_do_not_share_cache(tmp_path):
+    """Closures from the same factory shared one cache key: run(make_adder(100), 5)
+    used to return make_adder(1)'s cached 6."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+
+    def make_adder(n):
+        def adder(x):
+            return x + n
+
+        return adder
+
+    assert stash.run(make_adder(1), 5) == 6
+    assert stash.run(make_adder(100), 5) == 105
+
+
+def test_lambdas_do_not_share_cache(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    add_one = lambda x: x + 1
+    times_ten = lambda x: x * 10
+    assert stash.run(add_one, 5) == 6
+    assert stash.run(times_ten, 5) == 50
+
+
+class SimplePoint:
+    def __init__(self, x):
+        self.x = x
+
+
+def test_stashed_result_with_object_first_arg(tmp_path):
+    """Any object-valued first argument used to be misclassified as 'self',
+    raising AttributeError and corrupting the decorator's closure."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+
+    @stash.stashed_result
+    def scale(point, factor):
+        return point.x * factor
+
+    assert scale(SimplePoint(2), 3) == 6
+    assert scale(SimplePoint(5), 3) == 15
+
+
+def test_run_with_kwarg_named_default(tmp_path):
+    """User kwargs used to leak into stash.get(), colliding with its parameters."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+
+    def render(x, default="D"):
+        return f"{x}-{default}"
+
+    assert stash.run(render, 1, default="Z") == "1-Z"
+
+
+def test_run_builtin(tmp_path):
+    """run() on builtins used to crash (no writable __dict__)."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    assert stash.run(len, [1, 2, 3]) == 3
+
+
+def _mul(x, y=1):
+    return x * y
+
+
+def test_map_key_includes_common_kwargs(tmp_path):
+    """Two maps differing only in common kwargs used to share one stashed map."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    r1 = list(stash.map(_mul, objects=[1, 2], y=2, num_proc=1, progress=False))
+    r2 = list(stash.map(_mul, objects=[1, 2], y=3, num_proc=1, progress=False))
+    assert [r.result for r in r1] == [2, 4]
+    assert [r.result for r in r2] == [3, 6]
+
+
+def test_relative_dir_path_resolves_from_cwd(tmp_path, monkeypatch):
+    """Directory-style relative paths used to silently nest under
+    ~/.cache/hashstash instead of resolving from the current directory."""
+    monkeypatch.chdir(tmp_path)
+    stash = HashStash(root_dir="./mycache")
+    assert stash.root_dir == str(tmp_path / "mycache")
+    stash2 = HashStash(root_dir=os.path.join("data", "cache"))
+    assert stash2.root_dir == str(tmp_path / "data" / "cache")
+
+
+def test_bare_name_nests_under_config_root():
+    from hashstash.config import Config
+
+    stash = HashStash(root_dir="bare_name_regression")
+    assert stash.root_dir == os.path.join(Config().root_dir, "bare_name_regression")
+
+
 @pytest.mark.skipif(not _redis_available(), reason="no local redis server")
 def test_redis_clear_scoped_to_namespace():
     """clear() used to flushdb() the whole numbered Redis db, wiping other stashes

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -572,6 +572,17 @@ def test_memory_engine_works_without_ultradict(tmp_path, monkeypatch):
     monkeypatch.setattr(mem, "SHARED_MEMORY_CACHE", None)
 
 
+# --- Stage 7: test isolation -------------------------------------------------
+
+
+def test_default_stash_is_isolated_from_user_cache(isolated_default_root):
+    """The conftest isolation fixture used to patch a throwaway Config instance:
+    HashStash() still wrote to the real ~/.cache/hashstash during tests."""
+    stash = HashStash()
+    assert stash.root_dir.startswith(isolated_default_root)
+    assert not stash.root_dir.startswith(os.path.expanduser("~/.cache/hashstash"))
+
+
 # --- Stage 6: GraphStash -----------------------------------------------------
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,149 @@
+"""Regression tests for bugs found in the 2026-07 repository audit.
+
+Grouped by fix stage; each test names the defect it guards against.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+from hashstash import HashStash
+from hashstash.engines.base import BaseHashStash
+from hashstash.utils.encodings import encode_compressed
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# --- Stage 1: data loss & global state --------------------------------------
+
+
+def test_clear_file_style_root_dir_spares_siblings(tmp_path):
+    """clear() on a file-style root_dir must not rmtree the parent directory."""
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    precious = parent / "precious.txt"
+    precious.write_text("precious data")
+
+    stash = HashStash(root_dir=str(parent / "mycache.db"))
+    stash["k"] = "v"
+    stash.clear()
+
+    assert precious.exists()
+    assert parent.exists()
+
+
+def test_clear_standard_layout_removes_only_stash_dir(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    stash["k"] = "v"
+    stash.clear()
+    assert not os.path.exists(stash.path_dirname)
+    assert tmp_path.exists()
+
+
+def test_import_does_not_mutate_global_state():
+    """import hashstash must not install warnings filters (it used to blanket-ignore
+    every warning in the host app) nor set the multiprocessing start method (the old
+    code caught the wrong exception type and would crash on Windows)."""
+    code = (
+        "import warnings, multiprocessing as mp\n"
+        "n_before = len(warnings.filters)\n"
+        "import hashstash\n"
+        "assert len(warnings.filters) == n_before, 'import added warnings filters'\n"
+        "assert mp.get_start_method(allow_none=True) is None, 'import set mp start method'\n"
+    )
+    env = {**os.environ, "PYTHONPATH": REPO_ROOT}
+    result = subprocess.run(
+        [sys.executable, "-c", code], env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_set_propagates_write_errors(tmp_path):
+    """A failed write must raise, not silently drop the entry (was: bare log.error)."""
+
+    class FailingDB(dict):
+        def __setitem__(self, key, value):
+            raise OSError("disk full")
+
+    class FailingStash(BaseHashStash):
+        engine = "failing"
+        needs_lock = False
+
+        def get_db(self):
+            return FailingDB()
+
+    stash = FailingStash(root_dir=str(tmp_path / "cache"))
+    with pytest.raises(OSError):
+        stash["k"] = "v"
+
+
+def test_compression_failure_raises(monkeypatch):
+    """Compression errors must raise, not silently store uncompressed bytes that are
+    recorded as compressed (which made the entry permanently unreadable)."""
+    import zlib
+
+    def boom(data):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(zlib, "compress", boom)
+    with pytest.raises(RuntimeError):
+        encode_compressed(b"payload", "zlib")
+
+
+def test_diskcache_does_not_silently_evict(tmp_path):
+    """diskcache's default 1 GB least-recently-stored eviction must be disabled:
+    no other engine silently drops entries."""
+    pytest.importorskip("diskcache")
+    stash = HashStash(engine="diskcache", root_dir=str(tmp_path / "dc"))
+    with stash.db as db:
+        assert db.eviction_policy == "none"
+
+
+def test_pairtree_delete_method(tmp_path):
+    """delete() on the default engine used to raise NotImplementedError (only
+    __delitem__ was overridden)."""
+    stash = HashStash(engine="pairtree", root_dir=str(tmp_path / "pt"))
+    stash["a"] = 1
+    stash.delete("a")
+    assert "a" not in stash
+    with pytest.raises(KeyError):
+        stash.delete("a")
+
+
+def _redis_available():
+    try:
+        import redis
+    except ImportError:
+        return False
+    try:
+        redis.Redis(host="localhost", port=6379, socket_connect_timeout=0.5).ping()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _redis_available(), reason="no local redis server")
+def test_redis_clear_scoped_to_namespace():
+    """clear() used to flushdb() the whole numbered Redis db, wiping other stashes
+    (and any other application data) that hash to the same db number."""
+    from hashstash.engines.redis import get_db_number
+
+    # find two dbnames that collide on the same numbered redis db
+    name_a = "regression_clear_a"
+    name_b = next(
+        f"regression_clear_b{i}"
+        for i in range(1000)
+        if get_db_number(f"regression_clear_b{i}") == get_db_number(name_a)
+    )
+    a = HashStash(engine="redis", dbname=name_a)
+    b = HashStash(engine="redis", dbname=name_b)
+    try:
+        a["k"] = "va"
+        b["k"] = "vb"
+        a.clear()
+        assert a.get("k") is None
+        assert b.get("k") == "vb"
+    finally:
+        a.clear()
+        b.clear()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -123,6 +123,113 @@ def _redis_available():
         return False
 
 
+# --- Stage 2: cache-key stability & serializer correctness ------------------
+
+
+def test_dict_key_order_does_not_change_cache_key(tmp_path):
+    """Equal dicts with different insertion order must hit the same cache entry."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    stash[{"a": 1, "b": 2}] = "hit"
+    assert stash[{"b": 2, "a": 1}] == "hit"
+
+
+def test_kwargs_order_does_not_change_function_key(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    k1 = stash.encode_key((["f"], {"a": 1, "b": 2}))
+    k2 = stash.encode_key((["f"], {"b": 2, "a": 1}))
+    assert k1 == k2
+
+
+def test_set_serialization_is_deterministic_across_hash_seeds():
+    """Sets used to serialize in PYTHONHASHSEED-dependent order, changing the
+    cache key every interpreter restart."""
+    code = (
+        "from hashstash import serialize\n"
+        "print(serialize({'gamma', 'alpha', 'x', 'y', 'beta', 'z'}, serializer='hashstash'))\n"
+    )
+    outs = set()
+    for seed in ("0", "1", "2"):
+        env = {**os.environ, "PYTHONPATH": REPO_ROOT, "PYTHONHASHSEED": seed}
+        result = subprocess.run(
+            [sys.executable, "-c", code], env=env, capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        outs.add(result.stdout)
+    assert len(outs) == 1, f"set serialization varies with hash seed: {outs}"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {1: "one", 2: "two"},
+        {1.5: "float-key", True: "bool-key"},
+        {(1, 2): "tuple-key"},
+        {"__py__": "not.an.address", "__data__": "just a plain dict"},
+        {"__pytype__": "dict"},
+    ],
+)
+def test_dict_key_types_roundtrip(value, tmp_path):
+    """Non-string dict keys were silently JSON-coerced to strings (or crashed for
+    tuple keys); dicts containing reserved marker keys were misdeserialized."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    stash["k"] = value
+    assert stash["k"] == value
+
+
+def test_datetime_roundtrip(tmp_path):
+    """datetime used to fail at write time: __reduce__ args contain raw bytes that
+    json.dumps rejected."""
+    import datetime
+
+    value = datetime.datetime(2020, 1, 1, 12, 0)
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    stash["dt"] = value
+    assert stash["dt"] == value
+
+
+def test_complex_roundtrip(tmp_path):
+    """complex used to silently serialize to null (bare __reduce__ raises on
+    C-types; the exception was swallowed)."""
+    stash = HashStash(root_dir=str(tmp_path / "cache"))
+    stash["c"] = complex(1, 2)
+    assert stash["c"] == complex(1, 2)
+
+
+class EmptyPayload:
+    """Importable class whose to_dict() payload is empty (falsy)."""
+
+    def __init__(self, label="init"):
+        self.label = label
+
+    def to_dict(self):
+        return {}
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(label="from_dict")
+
+
+def test_empty_data_object_roundtrips_to_instance():
+    """An object whose to_dict() is empty used to deserialize to the class object
+    itself instead of an instance (falsy __data__ check)."""
+    from hashstash import deserialize, serialize
+
+    out = deserialize(
+        serialize(EmptyPayload(), serializer="hashstash"), serializer="hashstash"
+    )
+    assert isinstance(out, EmptyPayload), f"expected instance, got {out!r}"
+
+
+def test_unserializable_object_raises_not_none():
+    """Objects that cannot be reduced must raise, not silently become null."""
+    import threading
+
+    from hashstash import serialize
+
+    with pytest.raises(Exception):
+        serialize(threading.Lock(), serializer="hashstash")
+
+
 @pytest.mark.skipif(not _redis_available(), reason="no local redis server")
 def test_redis_clear_scoped_to_namespace():
     """clear() used to flushdb() the whole numbered Redis db, wiping other stashes

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -572,6 +572,86 @@ def test_memory_engine_works_without_ultradict(tmp_path, monkeypatch):
     monkeypatch.setattr(mem, "SHARED_MEMORY_CACHE", None)
 
 
+# --- Stage 6: GraphStash -----------------------------------------------------
+
+
+@pytest.fixture
+def graph(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "g"))
+    return stash.graph()
+
+
+def test_graph_edges_where_mixed_types_no_typeerror(graph):
+    """One edge storing a string weight used to TypeError every weight__gt query."""
+    graph.add_edge("a", "b", weight=5)
+    graph.add_edge("a", "c", weight="heavy")
+    graph.add_edge("a", "d", tag=7)
+    hits = graph.edges_where(weight__gt=1)
+    assert [(s, d) for s, d, r, p in hits] == [("a", "b")]
+    assert graph.edges_where(tag__contains="x") == []  # int prop: non-match, not crash
+
+
+def test_graph_node_returns_copy(graph):
+    """node() used to hand out the live cache dict: caller mutation silently
+    diverged the cache from disk."""
+    graph.add_node("a", role="original")
+    props = graph.node("a")
+    props["role"] = "HACKED"
+    assert graph.node("a")["role"] == "original"
+
+
+def test_graph_edges_of_returns_copies(graph):
+    graph.add_edge("a", "b", w=1)
+    edges = graph.edges_of("a")
+    edges[0][2]["w"] = 999
+    assert graph.edge("a", "b")["w"] == 1
+
+
+def test_graph_preload_warms_sink_nodes(graph):
+    """preload() iterated out-stash keys to warm the in-cache, so pure sink nodes
+    stayed cold."""
+    graph.add_edge("a", "b")
+    g2 = graph._stash.graph()
+    g2.preload()
+    assert "b" in g2._cache_in
+
+
+def test_graph_edges_between_returns_parallel_edges(graph):
+    graph.add_edge("a", "b", rel="knows", since=2020)
+    graph.add_edge("a", "b", rel="knows", since=2024)
+    graph.add_edge("a", "b", rel="likes")
+    knows = graph.edges_between("a", "b", rel="knows")
+    assert sorted(p["since"] for r, p in knows) == [2020, 2024]
+    assert len(graph.edges_between("a", "b")) == 3
+
+
+def test_graph_edges_where_rel_none_means_rel_none(graph):
+    """edges_where(rel=None) was a no-op filter returning every edge."""
+    graph.add_edge("a", "b")  # rel None
+    graph.add_edge("a", "c", rel="k")
+    hits = graph.edges_where(rel=None)
+    assert [(s, d) for s, d, r, p in hits] == [("a", "b")]
+    assert len(graph.edges_where()) == 2
+
+
+def test_graph_absent_prop_ne_semantics(graph):
+    graph.add_edge("a", "b", color="red")
+    graph.add_edge("a", "c")  # no color
+    hits = graph.edges_where(color__ne="blue")
+    assert sorted(d for s, d, r, p in hits) == ["b", "c"]
+
+
+def test_graph_interleaved_write_query_stays_fresh(graph):
+    """Every write used to nuke the key caches, and queries after writes could
+    miss just-written edges if caches went stale in the other direction."""
+    graph.add_edge("a", "b", n=1)
+    assert len(graph.edges_where(n__gte=1)) == 1
+    graph.add_edge("a", "c", n=2)
+    assert len(graph.edges_where(n__gte=1)) == 2
+    graph.add_edge("z", "a", n=3)  # brand-new source node
+    assert len(graph.edges_where(n__gte=1)) == 3
+
+
 @pytest.mark.skipif(not _redis_available(), reason="no local redis server")
 def test_redis_clear_scoped_to_namespace():
     """clear() used to flushdb() the whole numbered Redis db, wiping other stashes

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -457,6 +457,121 @@ def test_connection_pool_thread_safety(tmp_path):
     assert len(stash) == 8 * 20
 
 
+# --- Stage 5: engine fixes ---------------------------------------------------
+
+
+def test_unknown_engine_raises():
+    """Unknown engines used to silently fall back to pairtree."""
+    with pytest.raises(ValueError):
+        HashStash(engine="ldmb")  # typo of lmdb
+
+
+def test_jsonl_sees_other_writers(tmp_path):
+    """The JSONL keyset loaded once and never refreshed: a long-lived reader never
+    saw keys written by another instance/process."""
+    root = str(tmp_path / "cache")
+    reader = HashStash(engine="jsonl", root_dir=root)
+    assert reader.get("k") is None  # loads (empty) keyset
+
+    writer = HashStash(engine="jsonl", root_dir=root)
+    writer["k"] = "written elsewhere"
+
+    assert "k" in reader
+    assert reader.get("k") == "written elsewhere"
+
+
+def test_jsonl_overwrite_semantics_match_other_engines(tmp_path):
+    """With append_mode=False, jsonl.get_all returned every historical row while
+    every other engine returned only the latest."""
+    jstash = HashStash(engine="jsonl", root_dir=str(tmp_path / "j"), append_mode=False)
+    jstash["k"] = 1
+    jstash["k"] = 2
+    assert jstash.get_all("k") == [2]
+    assert jstash.items_l() == [("k", 2)]
+    # chaining contract: clear() returns self like the base engine
+    assert jstash.clear() is jstash
+
+
+def test_lmdb_two_instances_same_path(tmp_path):
+    """Two stash objects on one path used to open the LMDB environment twice in
+    one process ('environment already open', issue #9)."""
+    pytest.importorskip("lmdb")
+    root = str(tmp_path / "cache")
+    a = HashStash(engine="lmdb", root_dir=root)
+    b = HashStash(engine="lmdb", root_dir=root)
+    a["k"] = "va"
+    assert b["k"] == "va"
+    b["k2"] = "vb"
+    assert a["k2"] == "vb"
+    a.close()
+
+
+def test_pairtree_same_microsecond_appends_both_survive(tmp_path):
+    """Version filenames were bare microsecond timestamps: two writers in the same
+    microsecond silently overwrote each other. Filenames now carry a pid suffix."""
+    stash = HashStash(engine="pairtree", root_dir=str(tmp_path / "pt"), append_mode=True)
+    stash["k"] = "v1"
+    stash["k"] = "v2"
+    path = stash._get_path(stash.encode_key("k"))
+    versions = [f for f in os.listdir(path) if not f.startswith(".")]
+    assert len(versions) == 2
+    assert all("." in f for f in versions)  # pid suffix present
+    assert stash.get_all("k") == ["v1", "v2"]
+
+
+def test_dataframe_engine_set_contract(tmp_path):
+    """DataFrameHashStash.set() violated the base signature (no append param) and
+    never honored append_mode=False for dataframe values."""
+    pd = pytest.importorskip("pandas")
+    stash = HashStash(engine="dataframe", root_dir=str(tmp_path / "df"), append_mode=False)
+
+    df1 = pd.DataFrame({"a": [1, 2]})
+    df2 = pd.DataFrame({"a": [3, 4]})
+    stash.set("k", df1, append=None)  # base-contract signature
+    stash.set("k", df2)
+
+    path = stash._get_path(stash.encode_key("k"))
+    versions = [f for f in os.listdir(path) if not f.startswith(".")]
+    assert len(versions) == 1  # overwrite semantics honored
+
+    out = stash.get("k")
+    got = out.df if hasattr(out, "df") else out
+    assert list(got["a"]) == [3, 4]
+
+    # non-dataframe values still work through the pairtree path
+    stash["plain"] = {"x": 1}
+    assert stash["plain"] == {"x": 1}
+
+
+def test_shelve_engine_roundtrip(tmp_path):
+    """shelve existed in code but was never tested anywhere."""
+    stash = HashStash(engine="shelve", root_dir=str(tmp_path / "sh"))
+    stash["k"] = {"nested": [1, 2, 3]}
+    assert stash["k"] == {"nested": [1, 2, 3]}
+    del stash["k"]
+    assert "k" not in stash
+
+
+def test_memory_engine_works_without_ultradict(tmp_path, monkeypatch):
+    """memory is listed as a builtin engine but hard-required the optional
+    ultradict package at first use; it now degrades to a process-local dict."""
+    import hashstash.engines.memory as mem
+
+    monkeypatch.setattr(mem, "SHARED_MEMORY_CACHE", None)
+    real_import = __import__
+
+    def no_ultradict(name, *args, **kwargs):
+        if name == "UltraDict":
+            raise ImportError("simulated missing ultradict")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", no_ultradict)
+    stash = HashStash(engine="memory", root_dir=str(tmp_path / "mem"))
+    stash["k"] = "v"
+    assert stash["k"] == "v"
+    monkeypatch.setattr(mem, "SHARED_MEMORY_CACHE", None)
+
+
 @pytest.mark.skipif(not _redis_available(), reason="no local redis server")
 def test_redis_clear_scoped_to_namespace():
     """clear() used to flushdb() the whole numbered Redis db, wiping other stashes

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -7,11 +7,22 @@ from pandas.testing import assert_frame_equal
 from pathlib import Path
 from hashstash.constants import SERIALIZER_TYPES
 
-serializers = ['hashstash']
+from hashstash.config import get_working_serializers
+
+# every installed serializer gets the full round-trip suite (only 'hashstash'
+# was ever exercised before)
+serializers = get_working_serializers()
 
 @pytest.fixture(params=serializers)
 def serializer_type(request):
     return request.param
+
+
+def require_code_serialization(serializer_type):
+    """Skip for serializers that cannot round-trip locally-defined functions,
+    classes, or lambdas (pickle/jsonpickle serialize code objects by reference)."""
+    if serializer_type != "hashstash":
+        pytest.skip(f"{serializer_type} does not round-trip local code objects")
 
 @pytest.fixture
 def cache(serializer_type, tmp_path):
@@ -54,7 +65,8 @@ class TestSerializers:
         assert isinstance(result, pd.Series)
         assert result.equals(series)
 
-    def test_serialize_deserialize_function(self, cache):
+    def test_serialize_deserialize_function(self, cache, serializer_type):
+        require_code_serialization(serializer_type)
         def test_func(x):
             return x * 2
         
@@ -63,7 +75,8 @@ class TestSerializers:
         assert callable(result)
         assert result(3) == 6
 
-    def test_serialize_deserialize_class(self, cache):
+    def test_serialize_deserialize_class(self, cache, serializer_type):
+        require_code_serialization(serializer_type)
         class TestClass:
             def __init__(self, x):
                 self.x = x
@@ -78,7 +91,8 @@ class TestSerializers:
         assert instance.x == 5
         assert instance.method() == 10
 
-    def test_serialize_deserialize_instance(self, cache):
+    def test_serialize_deserialize_instance(self, cache, serializer_type):
+        require_code_serialization(serializer_type)
         class TestClass:
             def __init__(self, x):
                 self.x = x
@@ -114,7 +128,8 @@ class TestSerializers:
         assert isinstance(result, Path)
         assert str(result) == str(path)
 
-    def test_serialize_deserialize_complex_nested_structure(self, cache):
+    def test_serialize_deserialize_complex_nested_structure(self, cache, serializer_type):
+        require_code_serialization(serializer_type)
         complex_obj = {
             'list': [1, 2, np.array([3, 4, 5])],
             'dict': {'a': pd.Series([1, 2, 3]), 'b': Path('/tmp/test.txt')},

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -4,11 +4,8 @@ import pytest
 from unittest.mock import Mock, patch
 logger.setLevel(logging.CRITICAL+1)
 
-_CI = os.environ.get("CI") == "true"
-_SKIP_CI = "Known LMDB env-handle issue on CI — see issue #9"
 
 # Test stashed_result decorator
-@pytest.mark.skipif(_CI, reason=_SKIP_CI)
 def test_stashed_result():
     @stashed_result
     def example_function(x, y):
@@ -26,30 +23,29 @@ def test_stashed_result():
     result3 = example_function(3, 4)
     assert result3 == 7
 
-counter = 0
-tmp = Stash(engine='memory').clear()
+# module-level (importable, closure-free) so its cache identity is stable;
+# the counter lives in a module global that is not part of the function's identity
+_force_counter = {"n": 0}
 
-@tmp.stashed_result
-def incrementing_function():
-    global counter
-    counter += 1
-    return counter
-logger.setLevel(logging.DEBUG)
+
+def _incrementing_function():
+    _force_counter["n"] += 1
+    return _force_counter["n"]
+
+
 def test_stashed_result_force():
-    global counter
-    counter = 0  # Reset counter at the start of the test
-    
+    _force_counter["n"] = 0
+    stash = Stash(engine="memory", dbname="wrappers_force_test").clear()
+    incrementing_function = stash.stashed_result(_incrementing_function)
+
     # First call
-    result1 = incrementing_function()
-    assert result1 == 1
+    assert incrementing_function() == 1
 
     # Second call (should be cached)
-    result2 = incrementing_function()
-    assert result2 == 1
+    assert incrementing_function() == 1
 
     # Forced call
-    result3 = incrementing_function(_force=True)
-    assert result3 == 2
+    assert incrementing_function(_force=True) == 2
 
 # Test retry_patiently decorator
 def test_retry_patiently():
@@ -76,7 +72,6 @@ def test_retry_patiently_success():
     assert counter == 3
 
 # Test parallelized decorator
-@pytest.mark.skipif(_CI, reason=_SKIP_CI)
 def test_parallelized():
     with HashStash().tmp() as tmp:
         @parallelized(stash=tmp)
@@ -87,9 +82,7 @@ def test_parallelized():
         assert result == [2, 4, 6, 8]
 
 
-@pytest.mark.skipif(_CI, reason=_SKIP_CI)
 def test_parallelized_with_stashed_result():
-    logger.setLevel(logging.INFO)
     with Stash().tmp() as tmp:
 
         @parallelized(stash=tmp)
@@ -108,7 +101,6 @@ def test_parallelized_with_stashed_result():
         result3 = parallel_stashed_function([5, 6, 7, 8]).results
         assert result3 == [10, 12, 14, 16]
 
-@pytest.mark.skipif(_CI, reason=_SKIP_CI)
 def test_parallelized_with_stashed_result_single_input():
     with Stash().tmp() as tmp:
 

--- a/tests/test_written_at.py
+++ b/tests/test_written_at.py
@@ -149,9 +149,13 @@ class TestPrune:
     def test_prune_actually_deletes(self, stash):
         stash["k1"] = 1
         stash["k2"] = 2
+        # capture the midpoint BETWEEN the writes, with margin on both sides:
+        # deriving it from wall-clock after the k3 write was flaky on loaded CI
+        # runners (a slow write pushed k3's timestamp before the midpoint)
+        time.sleep(0.05)
+        midpoint = datetime.fromtimestamp(time.time(), tz=timezone.utc)
         time.sleep(0.05)
         stash["k3"] = 3
-        midpoint = datetime.fromtimestamp(time.time() - 0.03, tz=timezone.utc)
         count = stash.prune(older_than=midpoint, dry_run=False)
         assert count == 2  # k1, k2 are older than midpoint
         assert len(stash) == 1

--- a/tests/test_written_at.py
+++ b/tests/test_written_at.py
@@ -108,10 +108,12 @@ class TestBeforeAfterFilter:
 
 class TestBackwardCompatUnstamped:
     def test_unwrap_legacy_list_format(self):
-        """Pre-envelope storage was a raw list; verify _unwrap_envelope reads it with t=0."""
+        """A bare (non-envelope) list is ONE value with t=0. Treating it as multiple
+        versions silently corrupted list-valued caches (get() returned the last
+        element instead of the stored list)."""
         values, timestamps = _unwrap_envelope(["v1", "v2"])
-        assert values == ["v1", "v2"]
-        assert timestamps == [0.0, 0.0]
+        assert values == [["v1", "v2"]]
+        assert timestamps == [0.0]
 
     def test_unwrap_envelope_format(self):
         envelope = {
@@ -125,10 +127,8 @@ class TestBackwardCompatUnstamped:
 
     def test_legacy_entries_excluded_from_after_queries(self, stash):
         # Simulate a pre-feature entry by writing directly at engine layer with no envelope.
-        # This test only really applies to non-JSONL engines (JSONL always has per-row timestamps
-        # once written through the new code path). We just confirm _unwrap_envelope behavior: legacy
-        # => timestamp=0 => fails after=(any positive) filter.
-        values, timestamps = _unwrap_envelope(["legacy"])
+        # Legacy => timestamp=0 => fails after=(any positive) filter.
+        values, timestamps = _unwrap_envelope("legacy")
         kept = [(v, t) for v, t in zip(values, timestamps) if t > time.time() - 3600]
         assert kept == []  # legacy timestamp=0 is excluded from "after: last hour" query
 


### PR DESCRIPTION
Fixes every finding from a full-repository audit (~60 issues across engines, serializers, core API, locking, GraphStash, tests, CI, and packaging), in 9 stage commits with the test suite green at each boundary. Bumps version to **0.6.0**.

Suite: **709 passed, 103 skipped, 0 warnings** (was 585/94, with several inert or vacuous tests).

## Highlights by stage

**1. Critical data-loss & global state** (3ca2efa)
- `clear()` on a file-style `root_dir` no longer `rmtree`s the *parent* directory (verified data loss)
- `import hashstash` no longer suppresses all warnings globally nor forces the `fork` start method (which also crashed on Windows — the code caught the wrong exception type)
- `_set()` and compression failures raise instead of silently dropping/corrupting entries
- Redis `clear()` deletes only this stash's namespace instead of `flushdb()`ing a shared numbered db; diskcache's hidden 1 GB eviction default disabled; pairtree `delete()` implemented (raised `NotImplementedError`)

**2. Cache-key stability & serializer correctness** (d7bbbab)
- Equal dicts/kwargs now always encode to the same key (sort_keys); sets serialize deterministically instead of in `PYTHONHASHSEED` order
- Non-string dict keys (int/float/bool/tuple) round-trip via a tagged form instead of silently becoming strings or crashing; `datetime` serializes (used to fail hard); `complex` works (used to silently become `null`)
- ⚠️ canonical keys mean 0.5.x cached entries will miss (they were already unstable across interpreter restarts)

**3. None-vs-missing, function identity, path resolution** (546ae2d)
- Stored `None` is a value, not a miss; `None`-returning functions are cached
- Closures/lambdas include source + closure values in their cache identity: `make_adder(1)` and `make_adder(100)` no longer share results. Fixing this exposed a deeper bug: the `is_dir()` extension heuristic made **every function sub-stash collapse onto its parent directory**, ignoring its dbname entirely
- Directory-style relative `root_dir`s (`"data/cache"`, `"./x"`) resolve from the CWD; bare names still nest under `~/.cache/hashstash`
- `@stashed_result` no longer misclassifies any object-valued first argument as `self` (and no longer corrupts its own closure); `run()` stops leaking user kwargs into `get()`; works on builtins

**4. Real locking & connection pool** (8ac1de7)
- The old lock proceeded into the critical section on failed acquire, released other holders' locks, and never spanned processes (per-process `Manager`). Replaced with reentrant per-path file locks (`flock`/msvcrt) that the OS releases if the holder dies
- Append-mode read-modify-write is atomic (regression test: 4 processes × 5 appends, none lost); the connection pool is thread-safe and refcounted

**5. Engine layer** (150101a)
- Unknown/uninstalled engines and serializers **raise** with a pip hint instead of silently falling back to pairtree
- JSONL: keyset refreshes incrementally (long-lived readers see other writers); overwrite mode returns only the latest write like every other engine
- LMDB: process-global env registry — the root cause fix for #9 ("environment already open")
- Redis/Mongo: namespaces include `root_dir` (different roots no longer share keys); mongo's forced b64 actually sticks; host/port survive pickling into `stash.map` workers
- Pairtree: atomic writes (tmp+rename), pid-suffixed version filenames (same-microsecond writers no longer overwrite each other)
- DataFrame engine: honors the base `set()` contract and `append_mode=False`; stored dataframes are now actually readable back (extension routing never matched before); shelve + dataframe are first-class, documented, and tested
- memory engine degrades to a process-local dict without ultradict (it's listed as builtin)

**6. GraphStash** (7620b7c)
- `edges_where` no longer `TypeError`s when one edge stores a type-mismatched property; reads return copies (callers could silently diverge cache from disk); `preload()` warms sink nodes; new `edges_between()` for parallel edges; `rel=None` means "rel is None"; writes update caches in place instead of nuking key caches

**7. Tests & CI** (8dea419)
- Test isolation actually works: `Config` resolves `root_dir` at call time (new `HASHSTASH_ROOT_DIR` env var), so tests never touch `~/.cache/hashstash`. With #9 fixed underneath, the 8 CI skips and the 3.12 pin are removed
- CI runs on every push and PR (the old branch filter meant **PRs into main never ran tests**), across Python 3.9–3.14 + macOS, with a separate job testing redis/mongo against live services
- Importing tests no longer shells out to docker; vacuous "compression" assertions now measure stored bytes; ~13 duplicate test names deduped; pickle/jsonpickle and all compressors now round-trip tested

**8. pmap, logging, packaging, docs** (e34810b, 3a4ad2a)
- pmap worker exceptions **propagate** instead of becoming silent `None` results; cached `None`s aren't recomputed; GC'ing a slice no longer kills the global executor; broken pools are replaced
- Removed `[project.scripts] test = "pytest:main"` (installed a `test` command into every user's PATH); `mongo` shim → `pymongo`; license unified as **GPLv3** (LICENSE, classifier, README all agree now)
- README: new **Security** section (deserializing untrusted stashes executes code), engine list/doc drift fixed

## Known follow-ups
- README.ipynb (Colab badge target) predates GraphStash/TypedStash/jsonl and should be regenerated from README.md
- First run of the new CI matrix happens on this PR — 3.13/3.14 wheel availability for optional deps is the most likely source of noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
