### PR TITLE
feat: TTL, single-flight, stats, invalidation (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,37 @@ stash.get_all("k")    # -> ["v1", "v2"]  (full history)
 
 Use `append_mode=True` when you want reproducibility or audit history (e.g. caching LLM responses across prompt revisions). Leave it off for ordinary overwrite semantics.
 
+### TTL (time-to-live)
+
+Give a stash a `ttl` (seconds or a `timedelta`) and entries older than that read as absent — `get` returns the default, `in` says no, and `@stashed_result`/`run` recompute:
+
+```python
+stash = HashStash(ttl=3600)          # results live for an hour
+stash["k"] = expensive()             # fresh for 3600s, then a miss
+```
+
+TTL is enforced on read (works identically on every engine); expired entries still occupy storage until you reclaim them with `stash.prune(older_than=..., dry_run=False)`, which deliberately still sees expired entries.
+
+### Single-flight caching
+
+`stash.run`, `@stashed_result`, and `stash.get_set` are single-flight by default: concurrent callers (threads or processes on one machine) that miss on the same key wait for one compute instead of all executing the function. Opt out per call with `_single_flight=False` (or `single_flight=False` for `get_set`). The locks are striped files next to the stash, so they cannot span hosts — multi-host redis/mongo callers may still occasionally double-compute.
+
+### Statistics and invalidation
+
+```python
+stash.stats                    # {'hits': 10, 'misses': 3, 'sets': 3, 'deletes': 0}
+stash.reset_stats()
+
+@stashed_result
+def f(x): ...
+f(2)                           # computes
+f.invalidate(2)                # drops that one cached call signature -> True
+f(2)                           # recomputes
+stash.invalidate(key)          # plain-stash form
+```
+
+Counters are shared by every stash instance pointing at the same path, per process.
+
 ### `items()`, `keys()`, and `values()` are lazy
 
 All three are generators — they yield as they read, so you can iterate a multi-GB stash without loading it into memory:
@@ -256,6 +287,7 @@ stash = HashStash(
 
     # storage options
     append_mode=False,           # store all versions of a key/value pair
+    ttl=3600,                    # optional: entries expire after this many seconds
     clear=True                   # clear on init
 )
 

--- a/hashstash/__init__.py
+++ b/hashstash/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 from .constants import *
 from .config import *
 from .hashstash import *

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -2,6 +2,7 @@
 # circular, and whether a name has landed in the package namespace yet
 # depends on import order (spawn workers + editable installs order imports
 # differently). Never rely on the star-chain for stdlib names.
+from collections import Counter
 from collections.abc import MutableMapping
 from functools import cached_property
 from typing import Any
@@ -116,6 +117,24 @@ def get_lock(path):
 
 ENVELOPE_MARKER = "__hs_v1__"
 
+# single-flight key locks are striped across this many lock files per stash:
+# bounded lock-file count, negligible collision odds between distinct keys
+SINGLE_FLIGHT_STRIPES = 256
+
+# access counters shared by every stash instance pointing at the same path
+# (run()/attach_func create fresh sub-stash instances per call; their traffic
+# must land on the same counters the user reads via func.stash.stats)
+_stats_by_path = {}
+_stats_guard = threading.Lock()
+
+
+def _get_stats(path):
+    with _stats_guard:
+        stats = _stats_by_path.get(path)
+        if stats is None:
+            stats = _stats_by_path[path] = Counter()
+        return stats
+
 
 class _MissingType:
     """Sentinel distinguishing 'key absent' from a stored None value."""
@@ -208,6 +227,7 @@ class BaseHashStash(MutableMapping):
         "append_mode",
         "is_function_stash",
         "is_tmp",
+        "ttl",
         "_root_is_dir",
     ]
     metadata_cols = ["_version", "_written_at"]
@@ -232,12 +252,13 @@ class BaseHashStash(MutableMapping):
         is_tmp:bool=None,
         append_mode: bool = False,
         clear: bool = False,
+        ttl: Union[int, float, timedelta] = None,
         _root_is_dir: bool = None,
         **kwargs,
     ) -> None:
         config = Config()
         # self.name = name if name is not None else self.name
-        
+
         self.compress = get_compresser(
             compress if compress is not None else config.compress
         )
@@ -248,6 +269,13 @@ class BaseHashStash(MutableMapping):
         self.dbname = dbname if dbname is not None else self.dbname
         self.parent = parent
         self.children = [] if not children else children
+        # ttl (seconds or timedelta): entries older than this read as absent.
+        # Enforced on read, engine-agnostic; use prune() to reclaim storage.
+        if isinstance(ttl, timedelta):
+            ttl = ttl.total_seconds()
+        if ttl is not None and ttl <= 0:
+            raise ValueError(f"ttl must be positive, got {ttl!r}")
+        self.ttl = ttl
         self.is_function_stash = (
             is_function_stash
             if is_function_stash is not None
@@ -298,8 +326,9 @@ class BaseHashStash(MutableMapping):
             # path_dirname is a pre-existing directory we share with other files;
             # clear() must never remove it (see _owns_dir check there)
             self._owns_dir = False
-        
-        
+
+        self._stats = _get_stats(self.path)
+
         if clear:
             self.clear()
 
@@ -503,11 +532,22 @@ class BaseHashStash(MutableMapping):
         unencoded_value_setter,
         default=None,
         _force=False,
+        single_flight=True,
         **kwargs,
     ):
         unencoded_value = _MISSING
         if not _force:
             unencoded_value = self.get(unencoded_key, default=_MISSING, **kwargs)
+            if unencoded_value is _MISSING and single_flight:
+                # single-flight: concurrent callers missing on the same key wait
+                # for one compute instead of all running the setter
+                with self.key_lock(unencoded_key):
+                    unencoded_value = self.get(unencoded_key, default=_MISSING, **kwargs)
+                    if unencoded_value is _MISSING:
+                        log.debug("setting")
+                        unencoded_value = unencoded_value_setter()
+                        self.set(unencoded_key, unencoded_value)
+                return unencoded_value if unencoded_value is not _MISSING else default
         if unencoded_value is _MISSING:
             log.debug("setting")
             unencoded_value = unencoded_value_setter()
@@ -515,6 +555,18 @@ class BaseHashStash(MutableMapping):
         else:
             log.debug("getting")
         return unencoded_value if unencoded_value is not _MISSING else default
+
+    def key_lock(self, unencoded_key):
+        """Cross-process lock scoped to one key, for single-flight computes.
+
+        Locks are striped: the key hashes to one of SINGLE_FLIGHT_STRIPES file
+        locks next to the stash, so lock files stay bounded. Two different keys
+        occasionally share a stripe and serialize their computes — harmless.
+        Reentrant within a thread; spans processes on one machine (a file lock
+        cannot span hosts, so multi-host redis/mongo callers may still race)."""
+        encoded_key = self.encode_key(unencoded_key)
+        stripe = int(encode_hash(encoded_key), 16) % SINGLE_FLIGHT_STRIPES
+        return get_lock(f"{self.path}.sf{stripe}")
 
     @log.debug
     def get(
@@ -535,6 +587,8 @@ class BaseHashStash(MutableMapping):
             as_dataframe=as_dataframe,
             **kwargs,
         )
+        found = values is not None and (not isinstance(values, list) or bool(values))
+        self._stats["hits" if found else "misses"] += 1
         value = values[-1] if values else default
         return self.serialize(value) if as_string else value
 
@@ -556,6 +610,7 @@ class BaseHashStash(MutableMapping):
 
         decoded = self.decode_value(encoded_value)
         values, timestamps = _unwrap_envelope(decoded)
+        after = self._ttl_after(after, kwargs)
         values, timestamps = _filter_by_time(values, timestamps, before=before, after=after)
         if not values:
             return default
@@ -582,6 +637,7 @@ class BaseHashStash(MutableMapping):
 
             encoded_value = self.encode_value(new_unencoded_value)
             self._set(encoded_key, encoded_value)
+        self._stats["sets"] += 1
 
     @log.debug
     def run(
@@ -590,6 +646,7 @@ class BaseHashStash(MutableMapping):
         *args,
         _force=False,
         _store_args=True,
+        _single_flight=True,
         **kwargs,
     ):
         fstash = (
@@ -602,7 +659,6 @@ class BaseHashStash(MutableMapping):
             args = [get_object_from_method(func)] + args
         elif get_pytype(func) == "classmethod":
             args = [get_class_from_method(func)] + args
-        # func = unwrap_func(func)
         # underscore-prefixed kwargs are stash-control options: excluded from the
         # cache key and never passed to the function or to get()
         func_kwargs = {k: v for k, v in kwargs.items() if k and k[0] != "_"}
@@ -618,11 +674,26 @@ class BaseHashStash(MutableMapping):
                     f"Stash hit for {func.__name__} in {fstash}. Returning stashed result"
                 )
                 return res
+            if _single_flight:
+                # single-flight: concurrent callers missing on the same key wait
+                # for one compute instead of all executing the function (opt out
+                # per call with _single_flight=False)
+                with fstash.key_lock(unencoded_key):
+                    res = fstash.get(unencoded_key, default=_MISSING)
+                    if res is not _MISSING:
+                        log.debug(
+                            f"Stash hit for {func.__name__} after waiting on "
+                            f"another caller's compute"
+                        )
+                        return res
+                    return self._run_and_store(fstash, func, unencoded_key, args, func_kwargs)
 
-        # didn't find
         note = "Forced execution" if _force else "Stash miss"
         log.debug(f"{note} for {func.__name__}. Executing function.")
+        return self._run_and_store(fstash, func, unencoded_key, args, func_kwargs)
 
+    @staticmethod
+    def _run_and_store(fstash, func, unencoded_key, args, func_kwargs):
         funcx = unwrap_func(func)
         result = call_function_politely(funcx, *args, **func_kwargs)
         result = list(result) if is_generator(result) else result
@@ -630,7 +701,6 @@ class BaseHashStash(MutableMapping):
             f"Caching result for {func.__name__} under {serialize(unencoded_key)}"
         )
         fstash.set(unencoded_key, result)
-        # return unencoded_key
         return result
 
     def map(
@@ -763,6 +833,10 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def has(self, unencoded_key: Any) -> bool:
+        if self.ttl is not None:
+            # storage-level existence isn't enough: an expired entry must read
+            # as absent everywhere, or get_set/run would trust a dead key
+            return self.get(unencoded_key, default=_MISSING) is not _MISSING
         return self._has(self.encode_key(unencoded_key))
 
     @log.debug
@@ -844,6 +918,32 @@ class BaseHashStash(MutableMapping):
         if not self.has(unencoded_key):
             raise KeyError(unencoded_key)
         self._del(self.encode_key(unencoded_key))
+        self._stats["deletes"] += 1
+
+    def invalidate(self, *args, **kwargs) -> bool:
+        """Delete the cached result for one call signature.
+
+        On a function stash (``func.stash``), pass the same arguments as the
+        original call: ``func.stash.invalidate(2, 3)``. On a plain stash, pass
+        the key itself: ``stash.invalidate(key)``. Returns True if an entry was
+        deleted, False if there was nothing cached for that signature."""
+        if self.is_function_stash:
+            func_kwargs = {k: v for k, v in kwargs.items() if k and k[0] != "_"}
+            key = self.new_function_key(
+                *args, store_args=kwargs.get("_store_args", True), **func_kwargs
+            )
+        else:
+            if len(args) != 1 or kwargs:
+                raise TypeError(
+                    "invalidate() on a non-function stash takes exactly one "
+                    "argument: the key"
+                )
+            key = args[0]
+        try:
+            self.delete(key)
+            return True
+        except KeyError:
+            return False
 
     @log.debug
     def _del(self, encoded_key: Union[str, bytes]) -> None:
@@ -867,6 +967,18 @@ class BaseHashStash(MutableMapping):
         with self as cache, cache.db as db:
             for k in db:
                 yield k, db[k]
+
+    def _ttl_after(self, after, kwargs=None):
+        """Effective 'after' floor for reads: an explicit after wins; otherwise
+        the ttl floor applies unless apply_ttl=False was passed (prune() needs
+        raw access or expired entries could never be reclaimed)."""
+        if after is not None:
+            return after
+        if kwargs is not None and kwargs.pop("apply_ttl", None) is False:
+            return None
+        if self.ttl:
+            return time.time() - self.ttl
+        return None
 
     def _all_results(self, all_results=None):
         return all_results if all_results is not None else self.append_mode
@@ -956,6 +1068,16 @@ class BaseHashStash(MutableMapping):
     @log.debug
     def hash(self, data: bytes) -> str:
         return encode_hash(data)
+
+    @property
+    def stats(self):
+        """Access counters for this stash instance: hits, misses, sets, deletes.
+        Per-instance and in-memory only (not shared across processes)."""
+        return dict(self._stats)
+
+    def reset_stats(self):
+        self._stats.clear()
+        return self
 
     @property
     def stashed_result(self):
@@ -1261,10 +1383,12 @@ class BaseHashStash(MutableMapping):
         for key in list(self.keys()):
             total += 1
             # as_dataframe/as_list are honored by the dataframe engine (and harmlessly
-            # ignored elsewhere): prune needs plain dicts to read _written_at from
+            # ignored elsewhere): prune needs plain dicts to read _written_at from.
+            # apply_ttl=False: prune must see expired entries or it could never
+            # reclaim them
             entries = self.get_all(
                 key, default=None, with_metadata=True, all_results=True,
-                as_dataframe=False, as_list=True,
+                as_dataframe=False, as_list=True, apply_ttl=False,
             )
             if not entries:
                 continue

--- a/hashstash/engines/dataframe.py
+++ b/hashstash/engines/dataframe.py
@@ -44,6 +44,7 @@ class DataFrameHashStash(PairtreeHashStash):
             # honor overwrite semantics like pairtree: without this, every set()
             # accumulated another version file forever
             self._prune_dir(filepath_value)
+        self._stats["sets"] += 1
 
     @log.debug
     def get_all(
@@ -66,6 +67,7 @@ class DataFrameHashStash(PairtreeHashStash):
             all_results=self._all_results(all_results),
             with_metadata=True,
         )
+        after = self._ttl_after(after, kwargs)
         if before is not None or after is not None:
             timestamps = [p["_written_at"] for p in paths_ld]
             paths_ld, _ = _filter_by_time(paths_ld, timestamps, before=before, after=after)

--- a/hashstash/engines/jsonl.py
+++ b/hashstash/engines/jsonl.py
@@ -173,6 +173,7 @@ class JSONLHashStash(BaseHashStash):
             # every other engine (the log retains history but it is not queryable)
             values, timestamps = values[-1:], timestamps[-1:]
 
+        after = self._ttl_after(after, kwargs)
         values, timestamps = _filter_by_time(values, timestamps, before=before, after=after)
         if not values:
             return default
@@ -231,6 +232,7 @@ class JSONLHashStash(BaseHashStash):
         with self:
             self._append_line(obj)
             self._keyset.add(ks)
+        self._stats["sets"] += 1
 
     @log.debug
     def _set(self, encoded_key: str, encoded_value: str) -> None:

--- a/hashstash/engines/pairtree.py
+++ b/hashstash/engines/pairtree.py
@@ -110,6 +110,7 @@ class PairtreeHashStash(BaseHashStash):
             all_results=self._all_results(all_results),
             with_metadata=True,
         )
+        after = self._ttl_after(after, kwargs)
         if before is not None or after is not None:
             timestamps = [p["_written_at"] for p in paths_ld]
             paths_ld, _ = _filter_by_time(paths_ld, timestamps, before=before, after=after)

--- a/hashstash/utils/wrappers.py
+++ b/hashstash/utils/wrappers.py
@@ -113,6 +113,8 @@ def stashed_result(
             
         func_stash = stash.attach_func(func)
         wrapper.stash = func_stash
+        # decorated_func.invalidate(*args, **kwargs) drops one cached call signature
+        wrapper.invalidate = func_stash.invalidate
         return wrapper
 
     # Check if _func is a string (root_dir) or a function

--- a/tests/test_cache_semantics.py
+++ b/tests/test_cache_semantics.py
@@ -1,0 +1,239 @@
+"""Tests for the 0.7.0 cache-semantics features: TTL, single-flight,
+statistics, and per-call invalidation."""
+import os
+import subprocess
+import sys
+import time
+from datetime import timedelta
+
+import pytest
+
+from hashstash import HashStash, stashed_result
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# --- TTL ---------------------------------------------------------------------
+
+
+def test_ttl_expires_reads(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"), ttl=0.2)
+    stash["k"] = "v"
+    assert stash["k"] == "v"
+    assert "k" in stash
+    time.sleep(0.3)
+    assert stash.get("k") is None
+    assert "k" not in stash
+    with pytest.raises(KeyError):
+        stash["k"]
+
+
+def test_ttl_accepts_timedelta(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"), ttl=timedelta(milliseconds=200))
+    assert stash.ttl == pytest.approx(0.2)
+    stash["k"] = "v"
+    assert stash["k"] == "v"
+    time.sleep(0.3)
+    assert stash.get("k") is None
+
+
+def test_ttl_rejects_nonpositive(tmp_path):
+    with pytest.raises(ValueError):
+        HashStash(root_dir=str(tmp_path / "c"), ttl=0)
+
+
+@pytest.mark.parametrize("engine", ["pairtree", "sqlite", "jsonl", "memory"])
+def test_ttl_across_engines(engine, tmp_path):
+    if engine == "sqlite":
+        pytest.importorskip("sqlitedict")
+    stash = HashStash(engine=engine, root_dir=str(tmp_path / engine), ttl=0.2)
+    stash["k"] = {"payload": 1}
+    assert stash["k"] == {"payload": 1}
+    time.sleep(0.3)
+    assert stash.get("k") is None
+    assert "k" not in stash
+
+
+def test_ttl_refreshes_on_rewrite(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"), ttl=0.4)
+    stash["k"] = "v1"
+    time.sleep(0.25)
+    stash["k"] = "v2"  # fresh write restarts the clock
+    time.sleep(0.25)   # v1 would be expired by now; v2 is not
+    assert stash["k"] == "v2"
+
+
+def _tick(x):
+    _tick.calls.append(x)
+    return len(_tick.calls)
+
+
+_tick.calls = []
+
+
+def test_ttl_run_recomputes_after_expiry(tmp_path):
+    _tick.calls = []
+    stash = HashStash(root_dir=str(tmp_path / "c"), ttl=0.2)
+    assert stash.run(_tick, 5) == 1
+    assert stash.run(_tick, 5) == 1  # cached
+    time.sleep(0.3)
+    assert stash.run(_tick, 5) == 2  # expired -> recomputed
+    assert len(_tick.calls) == 2
+
+
+def test_ttl_prune_still_sees_expired(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"), ttl=0.1)
+    stash["k1"] = 1
+    stash["k2"] = 2
+    time.sleep(0.2)
+    # reads say absent...
+    assert stash.get("k1") is None
+    # ...but prune can still find and reclaim the expired entries
+    assert stash.prune(older_than=timedelta(seconds=0.05), dry_run=True) == 2
+
+
+def test_ttl_inherited_by_function_stash(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"), ttl=123)
+    fstash = stash.sub_function_results(_tick)
+    assert fstash.ttl == 123
+
+
+# --- single-flight -----------------------------------------------------------
+
+
+def test_single_flight_across_processes(tmp_path):
+    """N concurrent processes missing the same key must execute the function
+    once, not N times."""
+    pytest.importorskip("sqlitedict")
+    root = str(tmp_path / "cache")
+    marker_dir = tmp_path / "executions"
+    marker_dir.mkdir()
+
+    worker = (
+        "import sys, os, time, uuid\n"
+        f"sys.path.insert(0, {REPO_ROOT!r})\n"
+        "from hashstash import HashStash\n"
+        f"stash = HashStash(engine='sqlite', root_dir={root!r})\n"
+        "def slow(x):\n"
+        f"    open(os.path.join({str(marker_dir)!r}, uuid.uuid4().hex), 'w').close()\n"
+        "    time.sleep(0.5)\n"
+        "    return x * 2\n"
+        "print(stash.run(slow, 21))\n"
+    )
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", worker],
+            env={**os.environ, "PYTHONPATH": REPO_ROOT},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        for _ in range(4)
+    ]
+    outs = []
+    for p in procs:
+        out, err = p.communicate(timeout=120)
+        assert p.returncode == 0, err.decode()
+        # hashstash may log to stdout (e.g. "could not get source code" for a
+        # -c-defined function); the result is the last line
+        outs.append(out.decode().strip().splitlines()[-1])
+
+    assert outs == ["42"] * 4
+    executions = len(list(marker_dir.iterdir()))
+    assert executions == 1, f"expected 1 execution, got {executions}"
+
+
+def test_single_flight_opt_out(tmp_path):
+    """_single_flight=False must skip the key lock entirely (single caller
+    semantics are unchanged either way)."""
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    _tick.calls = []
+    assert stash.run(_tick, 9, _single_flight=False) == 1
+    assert stash.run(_tick, 9, _single_flight=False) == 1  # cached
+    assert len(_tick.calls) == 1
+
+
+def test_get_set_single_flight_threads(tmp_path):
+    """Concurrent threads missing the same key run the setter once."""
+    import threading
+
+    pytest.importorskip("sqlitedict")
+    stash = HashStash(engine="sqlite", root_dir=str(tmp_path / "c"))
+    calls = []
+    results = []
+
+    def setter():
+        calls.append(1)
+        time.sleep(0.3)
+        return "computed"
+
+    def worker():
+        results.append(stash.get_set("k", setter))
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert results == ["computed"] * 5
+    assert len(calls) == 1
+
+
+# --- stats -------------------------------------------------------------------
+
+
+def test_stats_counts(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    assert stash.stats == {}
+    stash["a"] = 1
+    stash["b"] = 2
+    _ = stash["a"]
+    _ = stash.get("missing")
+    _ = stash.get("missing2")
+    del stash["b"]
+
+    stats = stash.stats
+    assert stats["sets"] == 2
+    assert stats["hits"] == 1
+    assert stats["misses"] >= 2  # 'in'/delete checks may add hits, never fewer misses
+    assert stats["deletes"] == 1
+
+    stash.reset_stats()
+    assert stash.stats == {}
+
+
+def test_stats_via_stashed_result(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    _tick.calls = []
+    fn = stash.stashed_result(_tick)
+    fn(1)
+    fn(1)
+    fstats = fn.stash.stats
+    assert fstats["sets"] == 1
+    assert fstats["hits"] >= 1
+    assert fstats["misses"] >= 1
+
+
+# --- invalidate --------------------------------------------------------------
+
+
+def test_invalidate_function_call_signature(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    _tick.calls = []
+    fn = stash.stashed_result(_tick)
+
+    assert fn(7) == 1
+    assert fn(7) == 1  # cached
+    assert fn.invalidate(7) is True
+    assert fn(7) == 2  # recomputed
+    assert fn.invalidate(7) is True
+    assert fn.invalidate(7) is False  # nothing cached now
+
+
+def test_invalidate_plain_key(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    stash["k"] = "v"
+    assert stash.invalidate("k") is True
+    assert "k" not in stash
+    assert stash.invalidate("k") is False
+    with pytest.raises(TypeError):
+        stash.invalidate("k", extra="arg")


### PR DESCRIPTION
**Stacked on #12** (audit-fixes) — review just the top commit. Merge #12 first; GitHub will retarget this PR to main automatically when the audit-fixes branch is deleted.

Four cache-semantics features that build directly on the audit work (real cross-process locks, canonical keys, the None-sentinel). Version → **0.7.0**.

## TTL

```python
stash = HashStash(ttl=3600)   # seconds or a timedelta
```

Entries older than `ttl` read as absent everywhere — `get` returns the default, `in` says no, `run`/`@stashed_result`/`get_set` recompute. Enforced on read, so it works identically on every engine (the envelope `_written_at` timestamps were already there). `prune()` deliberately still sees expired entries so storage can be reclaimed; `ttl` is carried through `to_dict`, so function stashes inherit it.

## Single-flight caching

`run()`, `@stashed_result`, and `get_set()` now hold a striped cross-process key lock across the miss→compute→store window, with a double-check after acquisition: N concurrent callers on one machine execute the function **once** instead of N times. Regression-tested with 4 concurrent processes → exactly 1 execution. Reentrant per thread; opt out per call with `_single_flight=False`. 256 lock stripes bound the lock-file count. (A file lock can't span hosts — multi-host redis/mongo callers may still occasionally double-compute; documented.)

## Statistics

```python
stash.stats        # {'hits': 10, 'misses': 3, 'sets': 3, 'deletes': 0}
stash.reset_stats()
```

Counters are shared by all stash instances pointing at the same path within a process (necessary because `run()` constructs fresh sub-stash instances per call).

## Per-call invalidation

```python
@stashed_result
def f(x): ...
f(2); f.invalidate(2)   # True — drops that one cached signature
stash.invalidate(key)   # plain-stash form
```

## Tests

18 new tests in `tests/test_cache_semantics.py` covering TTL expiry/refresh/timedelta/multi-engine/prune interaction/function-stash inheritance, cross-process and cross-thread single-flight, opt-out, stats counting, and invalidation. Full suite: 727 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
