### PR TITLE
feat: complete the roadmap — graph index, exception caching, orjson, duckdb, leveldb, cbor2, lmdb auto-grow (v0.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ HashStash is a versatile caching library for Python that supports multiple stora
 
 - File-based
     - "__pairtree__" (no dependencies, no database; just organized folder and file structure; very fast; safe for concurrent writers)
-    - "__[lmdb](https://pypi.org/project/lmdb/)__" (single file, very efficient, slightly faster than pairtree)
+    - "__[lmdb](https://pypi.org/project/lmdb/)__" (single file, very efficient, slightly faster than pairtree; auto-grows its map on demand)
     - "__[diskcache](https://pypi.org/project/diskcache/)__" (similar to pairtree, but slower)
     - "__sqlite__" (using [sqlitedict](https://pypi.org/project/sqlitedict/))
+    - "__[duckdb](https://pypi.org/project/duckdb/)__" (embedded SQL database; indexed key-value store)
+    - "__[leveldb](https://pypi.org/project/plyvel/)__" (embedded LSM key-value store via plyvel; no fixed size to pre-allocate)
     - "__jsonl__" (no dependencies; single human-readable append-only log; best for read-heavy or inspectable caches — see note on concurrent writes below; call `stash.compact()` to reclaim space from overwritten/deleted rows)
     - "__shelve__" (standard library; simple dbm-backed store)
     - "__dataframe__" (pairtree layout that stores pandas/polars DataFrames natively as feather/parquet/csv files, requires [pandas](https://pypi.org/project/pandas/))
@@ -84,8 +86,11 @@ HashStash is a versatile caching library for Python that supports multiple stora
         - Serializes pandas dataframes using pyarrow if available
         - Faster than jsonpickle but with larger file sizes
         - Mostly JSON-based, with some binary data
+        - Uses [orjson](https://pypi.org/project/orjson/) to speed up value encoding when installed (cache keys stay stdlib-canonical either way)
     - "__[jsonpickle](https://pypi.org/project/jsonpickle/)__"
         - Flexible, battle-tested, but slowest
+    - "__[msgpack](https://pypi.org/project/msgpack/)__" / "__[cbor2](https://pypi.org/project/cbor2/)__"
+        - Fast, compact, binary, and **data-only** (cannot encode code) — a safe pairing with `safe=True` for shared caches
 
 - Not transportable between Python versions
     - "__pickle__"
@@ -215,6 +220,23 @@ stash.invalidate(key)          # plain-stash form
 ```
 
 Counters are shared by every stash instance pointing at the same path, per process.
+
+### Exception caching
+
+By default a function that raises is re-executed on every call. Opt into caching
+failures so an expensive call that fails isn't retried until you want it to:
+
+```python
+stash.run(fetch, url, _cache_exceptions=True, _exception_ttl=60)
+
+@stashed_result
+def fetch(url): ...
+fetch(url, _cache_exceptions=True)   # a raised exception is cached and re-raised
+```
+
+The original exception type is preserved (so `except OriginalError` still
+catches it); an `_exception_ttl` gives failures their own (usually shorter)
+lifetime, and `_force` bypasses the cached failure. Works under `safe=True`.
 
 ### Size-bounded eviction
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,54 +4,40 @@ Ideas that are proposed but **not yet implemented**, roughly ordered by
 value-per-effort. Contributions welcome — open an issue to discuss before
 starting anything substantial.
 
-## Near-term
+## Open
 
-### GraphStash query indexing
-`GraphStash.batch()` optimized the *write* side of the graph, but the read
-side (`edges_where`, `edges`, `num_edges`) still does an O(V+E) full scan on
-every query. Add secondary indexes — by `rel` and by edge property — so
-queries touch only matching edges instead of walking the whole graph.
-*Half-finished: the write-batching landed in v0.8; the query index did not.*
+### GraphStash edge-property indexing
+v0.9 added a `rel` index (`edges_where(rel=...)` visits only matching sources).
+Arbitrary edge-*property* predicates (`weight__gt=...`) still scan within that
+narrowed set. A per-property index (sorted structures for range operators)
+would speed property-heavy queries — a larger lift with careful
+maintenance-on-write.
 
-### Exception / negative caching
-Cache function **failures** (raised exceptions, or a sentinel "not found") so
-an expensive call that legitimately fails or returns nothing isn't
-re-executed on every invocation. Would extend `stash.run` / `get_set` with an
-opt-in `cache_exceptions=` (with its own shorter TTL, typically). Listed as an
-API gap in the original audit; never built.
+### Optimize `_serialize_custom`
+The recursive Python conversion to a JSON-safe structure dominates
+serialization time — it, not the final `json`/`orjson` dumps, is the real
+bottleneck (orjson's 10x dumps win only shows through as ~1.2x end-to-end
+because of it). A fast path that detects already-JSON-native values and hands
+them straight to the encoder — carefully, since tuples/non-str-keys/non-finite
+floats need the full path — would unlock much larger gains.
 
-## Engines
+### Async exception caching
+`@stashed_result` over `async def` works, and exception caching works for sync
+`run`/`get_set`, but `arun` doesn't yet negative-cache. Thread
+`_cache_exceptions` through the async path.
 
-### DuckDB engine
-An indexed, SQL-queryable engine with native DataFrame assembly — could
-eventually subsume the `dataframe` engine and make `assemble_df` fast at
-scale. Needs the `duckdb` dependency and real integration testing.
-
-### LMDB auto-grow
-`map_size` is configurable (and survives pickling) as of the audit work, but
-LMDB still hard-fails with `MapFullError` at the limit. Catch `MapFullError`,
-grow the map, and retry the transaction so long-lived stores don't wedge.
-
-### RocksDB / LevelDB engine
-A `plyvel`-based alternative to LMDB without a fixed `map_size`. Lower
-priority — LMDB already covers most of this niche.
-
-## Serializers
-
-### orjson value acceleration
-Use `orjson` to speed up the `hashstash` serializer's **value** path.
-Important constraint: **key** bytes must remain stdlib-`json` canonical
-(`sort_keys=True`) so cache-key hashes never depend on which JSON library is
-installed — otherwise the same key hashes differently across environments.
-
-### cbor2 serializer
-Another compact, data-only binary format alongside `msgpack`. Nice-to-have;
-`msgpack` already fills the fast-data-only slot (and pairs with `safe=True`).
+### LMDB `map_size` cap tuning
+Auto-grow is in (doubles on `MapFullError`, capped at 256 GB). The cap could be
+configurable per stash for very large stores.
 
 ---
 
-*Delivered in the v0.6–v0.8 cycle (for context): the full audit fix-set
-(v0.6), then TTL / single-flight / stats / invalidation (v0.7), then safe
-deserialization mode, the msgpack serializer, the fsspec engine, an async
-API, `GraphStash.batch()`, JSONL `compact()`, and `max_entries` eviction
-(v0.8).*
+## Delivered
+
+- **v0.6** — full audit fix-set (~60 issues).
+- **v0.7** — TTL, single-flight, stats, per-call invalidation.
+- **v0.8** — safe deserialization mode, msgpack serializer, fsspec engine, async
+  API, `GraphStash.batch()`, JSONL `compact()`, `max_entries` eviction.
+- **v0.9** — GraphStash `rel` index, exception/negative caching, DuckDB engine,
+  LevelDB engine (plyvel), LMDB auto-grow, orjson value acceleration, cbor2
+  serializer.

--- a/hashstash/__init__.py
+++ b/hashstash/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.8.0'
+__version__ = '0.9.0'
 from .constants import *
 from .config import *
 from .hashstash import *

--- a/hashstash/config.py
+++ b/hashstash/config.py
@@ -148,6 +148,13 @@ def get_working_engines():
     except ImportError:
         pass
 
+    try:
+        import duckdb
+
+        working_engines.add("duckdb")
+    except ImportError:
+        pass
+
     return working_engines
 
 

--- a/hashstash/config.py
+++ b/hashstash/config.py
@@ -186,6 +186,11 @@ def get_working_serializers():
         working_serializers.append('msgpack')
     except ImportError:
         pass
+    try:
+        import cbor2
+        working_serializers.append('cbor2')
+    except ImportError:
+        pass
     return working_serializers
 
 def get_serializer_type(serializer):

--- a/hashstash/config.py
+++ b/hashstash/config.py
@@ -148,6 +148,13 @@ def get_working_engines():
     except ImportError:
         pass
 
+    try:
+        import plyvel
+
+        working_engines.add("rocksdb")
+    except ImportError:
+        pass
+
     return working_engines
 
 

--- a/hashstash/constants.py
+++ b/hashstash/constants.py
@@ -51,6 +51,7 @@ ENGINE_TYPES = Literal[
     "mongo",
     "jsonl",
     "fsspec",
+    "duckdb",
 ]
 ENGINES = ENGINE_TYPES.__args__
 BUILTIN_ENGINES = ['memory', 'pairtree', 'shelve', 'jsonl']
@@ -65,6 +66,7 @@ ENGINE_INSTALL_HINTS = {
     "diskcache": "diskcache",
     "dataframe": "pandas numpy",
     "fsspec": "fsspec",
+    "duckdb": "duckdb",
 }
 
 # Performance testing constants

--- a/hashstash/constants.py
+++ b/hashstash/constants.py
@@ -51,6 +51,7 @@ ENGINE_TYPES = Literal[
     "mongo",
     "jsonl",
     "fsspec",
+    "rocksdb",
 ]
 ENGINES = ENGINE_TYPES.__args__
 BUILTIN_ENGINES = ['memory', 'pairtree', 'shelve', 'jsonl']
@@ -65,6 +66,7 @@ ENGINE_INSTALL_HINTS = {
     "diskcache": "diskcache",
     "dataframe": "pandas numpy",
     "fsspec": "fsspec",
+    "rocksdb": "plyvel",
 }
 
 # Performance testing constants

--- a/hashstash/constants.py
+++ b/hashstash/constants.py
@@ -107,6 +107,7 @@ SERIALIZER_TYPES = Literal[
     "jsonpickle",      # pretty flexible json replacement for pickle
     "pickle",          # fastest but not platform independent
     "msgpack",         # fast, compact, data-only (no code); requires msgpack
+    "cbor2",           # fast, compact, data-only (no code); requires cbor2
 ]
 DEFAULT_SERIALIZER = "hashstash"
 OPTIMAL_SERIALIZER = "hashstash"

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -149,6 +149,57 @@ class _MissingType:
 _MISSING = _MissingType()
 
 
+class HashStashCachedError(Exception):
+    """Raised for a cached exception whose original type couldn't be
+    reconstructed (e.g. a non-importable custom exception)."""
+
+
+# Cached exceptions are stored as a plain-data marker dict (not a serialized
+# exception object), so they read back even under safe mode and carry their own
+# optional expiry. The marker key is deliberately long to avoid colliding with
+# a user value that happens to be a dict.
+_CACHED_EXC_MARKER = "__hashstash_cached_exception_v1__"
+
+
+def _make_cached_exc(exc, expires_at):
+    # only keep exc.args if they are simple data — otherwise reconstruction falls
+    # back to the message, and we never risk the exc-cache write itself failing
+    raw_args = getattr(exc, "args", ())
+    if all(isinstance(a, (str, int, float, bool, type(None))) for a in raw_args):
+        args = list(raw_args)
+    else:
+        args = None
+    return {
+        _CACHED_EXC_MARKER: True,
+        "type": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        "message": str(exc),
+        "args": args,
+        "expires_at": expires_at,
+    }
+
+
+def _reconstruct_cached_exc(info):
+    type_name = info.get("type") or "builtins.Exception"
+    message = info.get("message", "")
+    args = info.get("args")
+    exc_type = None
+    try:
+        mod, _, name = type_name.rpartition(".")
+        exc_type = getattr(importlib.import_module(mod), name) if mod else None
+    except Exception:
+        exc_type = None
+    if isinstance(exc_type, type) and issubclass(exc_type, BaseException):
+        try:
+            return exc_type(*(args if args is not None else ([message] if message else [])))
+        except Exception:
+            return exc_type(message) if message else exc_type()
+    return HashStashCachedError(f"{type_name}: {message}")
+
+
+def _is_cached_exc(res):
+    return isinstance(res, dict) and res.get(_CACHED_EXC_MARKER) is True
+
+
 def _coerce_timestamp(dt):
     """Normalize a datetime or unix timestamp to a float unix timestamp (UTC)."""
     if dt is None:
@@ -555,28 +606,51 @@ class BaseHashStash(MutableMapping):
         default=None,
         _force=False,
         single_flight=True,
+        cache_exceptions=False,
+        exception_ttl=None,
         **kwargs,
     ):
         unencoded_value = _MISSING
         if not _force:
             unencoded_value = self.get(unencoded_key, default=_MISSING, **kwargs)
+            if unencoded_value is not _MISSING:
+                unencoded_value = self._resolve_hit(unencoded_value)  # may re-raise
             if unencoded_value is _MISSING and single_flight:
                 # single-flight: concurrent callers missing on the same key wait
                 # for one compute instead of all running the setter
                 with self.key_lock(unencoded_key):
                     unencoded_value = self.get(unencoded_key, default=_MISSING, **kwargs)
+                    if unencoded_value is not _MISSING:
+                        unencoded_value = self._resolve_hit(unencoded_value)
                     if unencoded_value is _MISSING:
                         log.debug("setting")
-                        unencoded_value = unencoded_value_setter()
-                        self.set(unencoded_key, unencoded_value)
+                        unencoded_value = self._call_setter(
+                            unencoded_key, unencoded_value_setter,
+                            cache_exceptions, exception_ttl,
+                        )
                 return unencoded_value if unencoded_value is not _MISSING else default
         if unencoded_value is _MISSING:
             log.debug("setting")
-            unencoded_value = unencoded_value_setter()
-            self.set(unencoded_key, unencoded_value)
+            unencoded_value = self._call_setter(
+                unencoded_key, unencoded_value_setter, cache_exceptions, exception_ttl,
+            )
         else:
             log.debug("getting")
         return unencoded_value if unencoded_value is not _MISSING else default
+
+    def _call_setter(self, unencoded_key, setter, cache_exceptions, exception_ttl):
+        try:
+            value = setter()
+        except Exception as e:
+            if cache_exceptions:
+                try:
+                    expires_at = (time.time() + exception_ttl) if exception_ttl else None
+                    self.set(unencoded_key, _make_cached_exc(e, expires_at))
+                except Exception:
+                    log.debug("could not negative-cache exception")
+            raise
+        self.set(unencoded_key, value)
+        return value
 
     def key_lock(self, unencoded_key):
         """Cross-process lock scoped to one key, for single-flight computes.
@@ -703,6 +777,17 @@ class BaseHashStash(MutableMapping):
         aged.sort(key=lambda kt: kt[1])
         return aged
 
+    def _resolve_hit(self, res):
+        """Interpret a cache hit. A normal value is returned as-is. A cached
+        exception that is still valid is re-raised; an expired one returns
+        _MISSING so the caller recomputes."""
+        if _is_cached_exc(res):
+            expires_at = res.get("expires_at")
+            if expires_at is not None and time.time() > expires_at:
+                return _MISSING
+            raise _reconstruct_cached_exc(res)
+        return res
+
     @log.debug
     def run(
         self,
@@ -711,6 +796,8 @@ class BaseHashStash(MutableMapping):
         _force=False,
         _store_args=True,
         _single_flight=True,
+        _cache_exceptions=False,
+        _exception_ttl=None,
         **kwargs,
     ):
         fstash = (
@@ -734,10 +821,12 @@ class BaseHashStash(MutableMapping):
         if not _force:
             res = fstash.get(unencoded_key, default=_MISSING)
             if res is not _MISSING:
-                log.debug(
-                    f"Stash hit for {func.__name__} in {fstash}. Returning stashed result"
-                )
-                return res
+                res = fstash._resolve_hit(res)  # re-raises a cached exception
+                if res is not _MISSING:
+                    log.debug(
+                        f"Stash hit for {func.__name__} in {fstash}. Returning stashed result"
+                    )
+                    return res
             if _single_flight:
                 # single-flight: concurrent callers missing on the same key wait
                 # for one compute instead of all executing the function (opt out
@@ -745,21 +834,44 @@ class BaseHashStash(MutableMapping):
                 with fstash.key_lock(unencoded_key):
                     res = fstash.get(unencoded_key, default=_MISSING)
                     if res is not _MISSING:
-                        log.debug(
-                            f"Stash hit for {func.__name__} after waiting on "
-                            f"another caller's compute"
-                        )
-                        return res
-                    return self._run_and_store(fstash, func, unencoded_key, args, func_kwargs)
+                        res = fstash._resolve_hit(res)
+                        if res is not _MISSING:
+                            log.debug(
+                                f"Stash hit for {func.__name__} after waiting on "
+                                f"another caller's compute"
+                            )
+                            return res
+                    return self._run_and_store(
+                        fstash, func, unencoded_key, args, func_kwargs,
+                        _cache_exceptions, _exception_ttl,
+                    )
 
         note = "Forced execution" if _force else "Stash miss"
         log.debug(f"{note} for {func.__name__}. Executing function.")
-        return self._run_and_store(fstash, func, unencoded_key, args, func_kwargs)
+        return self._run_and_store(
+            fstash, func, unencoded_key, args, func_kwargs,
+            _cache_exceptions, _exception_ttl,
+        )
 
     @staticmethod
-    def _run_and_store(fstash, func, unencoded_key, args, func_kwargs):
+    def _run_and_store(
+        fstash, func, unencoded_key, args, func_kwargs,
+        cache_exceptions=False, exception_ttl=None,
+    ):
         funcx = unwrap_func(func)
-        result = call_function_politely(funcx, *args, **func_kwargs)
+        try:
+            result = call_function_politely(funcx, *args, **func_kwargs)
+        except Exception as e:
+            if cache_exceptions:
+                # negative caching: a later call re-raises this instead of
+                # re-executing. Guard the write so a serialization hiccup on the
+                # marker never masks the real exception.
+                try:
+                    expires_at = (time.time() + exception_ttl) if exception_ttl else None
+                    fstash.set(unencoded_key, _make_cached_exc(e, expires_at))
+                except Exception:
+                    log.debug("could not negative-cache exception")
+            raise
         result = list(result) if is_generator(result) else result
         log.debug(
             f"Caching result for {func.__name__} under {serialize(unencoded_key)}"

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -1556,6 +1556,7 @@ def HashStash(
         "dataframe": ("hashstash.engines.dataframe", "DataFrameHashStash"),
         "jsonl": ("hashstash.engines.jsonl", "JSONLHashStash"),
         "fsspec": ("hashstash.engines.fsspec", "FsspecHashStash"),
+        "rocksdb": ("hashstash.engines.rocksdb", "RocksDBHashStash"),
     }
     module_name, class_name = engine_registry[engine]
     try:

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -1556,6 +1556,7 @@ def HashStash(
         "dataframe": ("hashstash.engines.dataframe", "DataFrameHashStash"),
         "jsonl": ("hashstash.engines.jsonl", "JSONLHashStash"),
         "fsspec": ("hashstash.engines.fsspec", "FsspecHashStash"),
+        "duckdb": ("hashstash.engines.duckdb_engine", "DuckDBHashStash"),
     }
     module_name, class_name = engine_registry[engine]
     try:

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -612,7 +612,7 @@ class BaseHashStash(MutableMapping):
         found = values is not None and (not isinstance(values, list) or bool(values))
         self._stats["hits" if found else "misses"] += 1
         value = values[-1] if values else default
-        return self.serialize(value) if as_string else value
+        return self.serialize(value, as_string=True) if as_string else value
 
     @log.debug
     def get_all(

--- a/hashstash/engines/dataframe.py
+++ b/hashstash/engines/dataframe.py
@@ -125,7 +125,7 @@ class DataFrameHashStash(PairtreeHashStash):
         if values is None: return default
         if is_dataframe(values): return values
         value = values[-1] if values else default
-        return self.serialize(value) if as_string else value
+        return self.serialize(value, as_string=True) if as_string else value
         # if values is None:
         #     return default
         

--- a/hashstash/engines/duckdb_engine.py
+++ b/hashstash/engines/duckdb_engine.py
@@ -1,0 +1,120 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from typing import Any
+from typing import Union
+import os
+
+from . import *
+
+
+class DuckDBHashStash(BaseHashStash):
+    """Key-value engine backed by a single DuckDB table.
+
+    Keys and values are stored as BLOBs. The base encoder hands us bytes
+    (``string_keys``/``string_values`` are False), and DuckDB returns BLOB
+    columns as ``bytes``, so the round-trip is byte-consistent in both
+    directions. This is a solid key-value store; it does NOT attempt native
+    DataFrame assembly.
+    """
+
+    engine = "duckdb"
+    filename = "data.duckdb"
+    # DuckDB round-trips BLOB columns as bytes; keep keys/values as bytes so
+    # what we store is exactly what we read back (a str stored in a BLOB comes
+    # back as bytes anyway, which would desync string_keys/string_values).
+    string_keys = False
+    string_values = False
+    # DuckDB manages its own concurrency (single-writer per file); a local file
+    # lock can't coordinate across processes for it anyway.
+    needs_lock = False
+    needs_reconnect = False
+
+    @log.debug
+    @retry_patiently()
+    def get_db(self):
+        import duckdb
+
+        os.makedirs(self.path_dirname, exist_ok=True)
+        conn = duckdb.connect(self.path)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS hashstash (key BLOB PRIMARY KEY, value BLOB)"
+        )
+        return conn
+
+    @staticmethod
+    def _as_blob(x):
+        """DuckDB binds bytes to BLOB; encode str keys/values consistently."""
+        return x.encode("utf-8") if isinstance(x, str) else x
+
+    @log.debug
+    def _set(self, encoded_key: Union[str, bytes], encoded_value: Union[str, bytes]) -> None:
+        with self.db as db:
+            db.execute(
+                "INSERT OR REPLACE INTO hashstash (key, value) VALUES (?, ?)",
+                [self._as_blob(encoded_key), self._as_blob(encoded_value)],
+            )
+
+    @log.debug
+    def _get(self, encoded_key: Union[str, bytes], default: Any = None) -> Any:
+        with self.db as db:
+            row = db.execute(
+                "SELECT value FROM hashstash WHERE key = ?",
+                [self._as_blob(encoded_key)],
+            ).fetchone()
+        return row[0] if row is not None else default
+
+    @log.debug
+    def _has(self, encoded_key: Union[str, bytes]) -> bool:
+        with self.db as db:
+            row = db.execute(
+                "SELECT 1 FROM hashstash WHERE key = ? LIMIT 1",
+                [self._as_blob(encoded_key)],
+            ).fetchone()
+        return row is not None
+
+    @log.debug
+    def _del(self, encoded_key: Union[str, bytes]) -> None:
+        with self.db as db:
+            db.execute(
+                "DELETE FROM hashstash WHERE key = ?",
+                [self._as_blob(encoded_key)],
+            )
+
+    @log.debug
+    def __len__(self) -> int:
+        with self.db as db:
+            return db.execute("SELECT COUNT(*) FROM hashstash").fetchone()[0]
+
+    @log.debug
+    def _keys(self):
+        with self.db as db:
+            for row in db.execute("SELECT key FROM hashstash").fetchall():
+                yield row[0]
+
+    @log.debug
+    def _values(self):
+        with self.db as db:
+            for row in db.execute("SELECT value FROM hashstash").fetchall():
+                yield row[0]
+
+    @log.debug
+    def _items(self):
+        with self.db as db:
+            for row in db.execute("SELECT key, value FROM hashstash").fetchall():
+                yield row[0], row[1]
+
+    @log.debug
+    def clear(self) -> "DuckDBHashStash":
+        # base clear() closes the pooled connection (releasing DuckDB's file
+        # lock) and removes path_dirname; also drop the write-ahead-log left
+        # beside the db file when we don't own the whole directory.
+        super().clear()
+        wal = self.path + ".wal"
+        if os.path.exists(wal):
+            try:
+                os.remove(wal)
+            except Exception as e:
+                log.debug(f"error removing DuckDB wal {wal}: {e}")
+        return self

--- a/hashstash/engines/lmdb.py
+++ b/hashstash/engines/lmdb.py
@@ -20,6 +20,9 @@ class LMDBHashStash(BaseHashStash):
     filename_is_dir = True
     needs_lock = False  # LMDB has its own multi-reader/single-writer locking
     to_dict_attrs = BaseHashStash.to_dict_attrs + ["map_size"]
+    # Ceiling for auto-grow. A wedged write that keeps raising MapFullError would
+    # otherwise double map_size forever; stop at 256 GB and surface the error.
+    max_map_size = 256 * 1024**3  # 256 GB
 
     def __init__(self, *args, map_size=10 * 1024**3, **kwargs):  # Default to 10GB
         self.map_size = map_size
@@ -66,19 +69,69 @@ class LMDBHashStash(BaseHashStash):
                     raise
                 self._drop_env()  # force a fresh environment on the next attempt
 
+    def _grow_map(self):
+        """Double map_size (capped at max_map_size) and apply it to the live,
+        registry-owned environment. LMDB has a fixed map_size and raises
+        MapFullError once the map fills; set_mapsize enlarges it in place so we
+        keep sharing the one env per path (issue #9) rather than reopening.
+
+        Raises lmdb.MapFullError if the cap is already reached, so a genuinely
+        unbounded write can't loop forever.
+        """
+        import lmdb
+        if self.map_size >= self.max_map_size:
+            raise lmdb.MapFullError(
+                f"LMDB map is full and map_size cap ({self.max_map_size} bytes) "
+                f"is reached; refusing to grow further"
+            )
+        self.map_size = min(self.map_size * 2, self.max_map_size)
+        # set_mapsize on the current env keeps the shared registry entry valid;
+        # self.map_size is in to_dict_attrs so the grown size survives pickling.
+        self.get_db().set_mapsize(self.map_size)
+        log.debug(f"grew LMDB map_size to {self.map_size} bytes for {self.path}")
+
+    def _write(self, fn):
+        """Run fn(txn) inside a write transaction, growing the map on MapFullError.
+
+        A context manager can only yield once, so it can't re-run the caller's
+        puts after a mid-transaction MapFullError — writes go through this
+        callable-based path instead, which re-executes the whole transaction on a
+        fresh txn after each grow. Generic lmdb.Error keeps the stale-env retry
+        that get_transaction gives reads.
+        """
+        import lmdb
+        max_retries = 3
+        attempt = 0
+        while True:
+            try:
+                with self.get_db().begin(write=True) as txn:
+                    return fn(txn)
+            except lmdb.MapFullError:
+                # subclass of lmdb.Error, so this must come first. Don't drop the
+                # env: grow it in place and retry the operation.
+                self._grow_map()  # raises if the cap is hit
+            except lmdb.Error as e:
+                attempt += 1
+                log.debug(f"LMDB write error (attempt {attempt}/{max_retries}): {e}")
+                if attempt >= max_retries:
+                    raise
+                self._drop_env()  # force a fresh environment on the next attempt
+
     def _set(self, encoded_key, encoded_value):
-        with self.get_transaction(write=True) as txn:
+        def op(txn):
             txn.put(self._encode_key_key(encoded_key), encoded_key)
             txn.put(self._encode_key_value(encoded_key), encoded_value)
+        self._write(op)
 
     def _get(self, encoded_key):
         with self.get_transaction(write=False) as txn:
             return txn.get(self._encode_key_value(encoded_key))
 
     def _del(self, encoded_key):
-        with self.get_transaction(write=True) as txn:
+        def op(txn):
             txn.delete(self._encode_key_key(encoded_key))
             txn.delete(self._encode_key_value(encoded_key))
+        self._write(op)
 
     def __len__(self):
         with self.get_transaction(write=False) as txn:

--- a/hashstash/engines/rocksdb.py
+++ b/hashstash/engines/rocksdb.py
@@ -1,0 +1,116 @@
+# Explicit stdlib imports: this package's `from . import *` chains are
+# circular, and whether a name has landed in the package namespace yet
+# depends on import order (spawn workers + editable installs order imports
+# differently). Never rely on the star-chain for stdlib names.
+from contextlib import contextmanager
+import os
+
+from . import *
+import threading
+
+# One plyvel.DB handle per path per process. LevelDB is single-process
+# single-writer and takes an exclusive lock on its directory: opening the same
+# directory twice in one process raises ("IO error: lock ... Resource
+# temporarily unavailable"). A per-instance handle would do exactly that
+# whenever two stash objects share a path, so we cache one handle per path —
+# mirroring lmdb.py's _lmdb_envs.
+_plyvel_dbs = {}
+_plyvel_dbs_guard = threading.Lock()
+
+
+class RocksDBHashStash(BaseHashStash):
+    """Embedded key-value store backed by LevelDB via the ``plyvel`` driver.
+
+    A single-directory alternative to LMDB that grows on demand: unlike LMDB
+    there is no fixed ``map_size`` to pre-allocate — LevelDB's LSM tree expands
+    as needed. LevelDB is single-process single-writer and locks its own
+    directory, so no external cross-process lock is required
+    (``needs_lock = False``).
+
+    Keys and values are the raw encoded bytes from the stash encoder, stored
+    directly (``db.put(encoded_key, encoded_value)``) — LevelDB is a plain
+    ordered byte-keyed KV store, so no auxiliary index is needed.
+
+    Named ``rocksdb`` for its RocksDB-family LSM lineage; the concrete backend
+    is LevelDB (``pip install plyvel``, plus the system ``leveldb`` library).
+    """
+
+    engine = "rocksdb"
+    filename_is_dir = True
+    needs_lock = False  # LevelDB locks its own directory (single writer)
+    string_keys = False  # plyvel wants bytes keys
+    string_values = False  # plyvel wants bytes values
+
+    @log.debug
+    def get_db(self):
+        with _plyvel_dbs_guard:
+            db = _plyvel_dbs.get(self.path)
+            if db is None:
+                import plyvel
+
+                os.makedirs(self.path_dirname, exist_ok=True)
+                db = plyvel.DB(self.path, create_if_missing=True)
+                _plyvel_dbs[self.path] = db
+            return db
+
+    def _drop_db(self):
+        with _plyvel_dbs_guard:
+            db = _plyvel_dbs.pop(self.path, None)
+        if db is not None:
+            try:
+                db.close()
+            except Exception as e:
+                log.debug(f"error closing LevelDB db: {e}")
+
+    @contextmanager
+    def get_connection(self):
+        # bypass the base connection pool: handles live in _plyvel_dbs, and
+        # pooling the same object twice would let pool cleanup close a handle the
+        # registry still serves (mirrors lmdb.py)
+        yield self.get_db()
+
+    def _set(self, encoded_key, encoded_value):
+        self.get_db().put(encoded_key, encoded_value)
+
+    def _get(self, encoded_key):
+        return self.get_db().get(encoded_key)
+
+    def _del(self, encoded_key):
+        self.get_db().delete(encoded_key)
+
+    def _has(self, encoded_key):
+        return self.get_db().get(encoded_key) is not None
+
+    def __len__(self):
+        # LevelDB has no O(1) count; iterate keys only (values not decoded)
+        return sum(1 for _ in self.get_db().iterator(include_value=False))
+
+    def _keys(self):
+        for key in self.get_db().iterator(include_value=False):
+            yield key
+
+    def _values(self):
+        for value in self.get_db().iterator(include_key=False):
+            yield value
+
+    def _items(self):
+        for key, value in self.get_db().iterator():
+            yield key, value
+
+    @staticmethod
+    def _close_connection(connection):
+        if connection is not None:
+            try:
+                connection.close()
+            except Exception as e:
+                log.debug(f"error closing LevelDB connection: {e}")
+
+    def clear(self):
+        # close the handle first so the directory isn't locked when removed
+        self._drop_db()
+        super().clear()
+        return self
+
+    def close(self):
+        self._drop_db()
+        super().close()

--- a/hashstash/graph.py
+++ b/hashstash/graph.py
@@ -93,7 +93,11 @@ class GraphStash:
     Performance: add_edge() rewrites the source and target adjacency
     lists on every call — O(degree) I/O per insert, quadratic in the
     final degree when building a hub incrementally. Use add_edges_bulk()
-    for bulk loads; it groups writes per node.
+    or ``with g.batch():`` for bulk loads; they group writes per node.
+    edges_where(rel=...) is served from a secondary rel index (built
+    lazily, maintained on add, rebuilt after removes), so a rel-filtered
+    query visits only sources with that rel instead of the whole graph;
+    queries without an exact rel filter still do a full scan.
     """
 
     def __init__(self, stash, name="graph"):
@@ -113,8 +117,15 @@ class GraphStash:
         self._batching = False
         self._dirty_out = set()
         self._dirty_in = set()
+        # secondary index: rel -> set of source node_ids that have >=1 out-edge
+        # with that rel. Lets edges_where(rel=...) visit only relevant sources
+        # instead of scanning every node. Built lazily, maintained incrementally
+        # on add; invalidated (rebuilt on next query) on remove.
+        self._rel_index = None
 
     def _invalidate(self, node_id=None):
+        # any structural change drops the rel index; adds re-maintain it in place
+        self._rel_index = None
         if node_id is None:
             self._cache_nodes.clear()
             self._cache_out.clear()
@@ -127,6 +138,31 @@ class GraphStash:
             self._cache_in.pop(node_id, None)
             self._cache_node_keys = None
             self._cache_out_keys = None
+
+    def _ensure_rel_index(self):
+        if self._rel_index is not None:
+            return
+        idx = defaultdict(set)
+        for src in self._out_keys():
+            for _dst, rel, _props in self._get_out(src):
+                idx[rel].add(src)
+        self._rel_index = idx
+
+    def _rel_sources(self, rel):
+        """Source nodes with at least one out-edge of exactly this rel."""
+        self._ensure_rel_index()
+        return self._rel_index.get(rel, set())
+
+    def _index_add(self, src, rel):
+        # keep the index current on adds without a full rebuild (no-op if the
+        # index hasn't been built yet — it'll pick everything up when built)
+        if self._rel_index is not None:
+            self._rel_index[rel].add(src)
+
+    def rels(self):
+        """Sorted list of distinct relationship types present in the graph."""
+        self._ensure_rel_index()
+        return sorted(self._rel_index.keys(), key=lambda r: (r is not None, r))
 
     def _get_node_props(self, node_id):
         if node_id not in self._cache_nodes:
@@ -260,6 +296,8 @@ class GraphStash:
         in_list.append((src, rel, edge_props))
         self._cache_in[dst] = in_list
 
+        self._index_add(src, rel)
+
         if self._batching:
             # defer the writes; flush persists each dirty node once
             self._dirty_out.add(src)
@@ -361,12 +399,22 @@ class GraphStash:
         are non-matches, not errors. An absent property fails every
         predicate except __ne.
 
+        An exact ``rel=`` filter is served from the rel index, so the query
+        visits only sources that have an edge of that rel rather than scanning
+        the whole graph; other predicates are then applied within that set.
+
         Returns list of (src, dst, rel, props) tuples.
         """
         if rel is not _UNSET:
             kwargs["rel"] = rel
+        # index fast-path: an exact rel equality ("rel" in kwargs, as opposed to
+        # rel__contains etc.) means only sources indexed under that rel can match
+        if "rel" in kwargs:
+            sources = self._rel_sources(kwargs["rel"])
+        else:
+            sources = self._out_keys()
         results = []
-        for src in self._out_keys():
+        for src in sources:
             src_props = None
             for dst, edge_rel, props in self._get_out(src):
                 if src_props is None:
@@ -375,6 +423,11 @@ class GraphStash:
                 if _match(src_props, dst_props, edge_rel, props, kwargs):
                     results.append((src, dst, edge_rel, dict(props)))
         return results
+
+    def edges_with_rel(self, rel):
+        """All edges of a given rel as (src, dst, rel, props) tuples — the
+        index fast-path, without predicate filtering."""
+        return self.edges_where(rel=rel)
 
     def add_edges_bulk(self, edges):
         """Add edges in batch, minimizing read-modify-write cycles.
@@ -398,6 +451,7 @@ class GraphStash:
             props = dict(props)  # detach from the caller's dict
             out_new[src].append((dst, rel, props))
             in_new[dst].append((src, rel, props))
+            self._index_add(src, rel)
 
         for src, new_entries in out_new.items():
             out_list = list(self._get_out(src))

--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -87,12 +87,62 @@ SAFE_REDUCER_CONSTRUCTORS = frozenset({
 })
 
 
+# orjson accelerates the VALUE serialization path (dumps/loads of the already
+# JSON-safe structure _serialize_custom produces). It is NEVER used for cache
+# KEYS: those must stay stdlib-json canonical (sort_keys=True) so a key hashes
+# to the same bytes whether or not orjson happens to be installed. orjson also
+# rejects a few things stdlib json accepts (ints beyond 64 bits), so value
+# serialization falls back to stdlib json on any orjson error.
+_orjson = None
+_orjson_checked = False
+
+
+def _get_orjson():
+    global _orjson, _orjson_checked
+    if not _orjson_checked:
+        _orjson_checked = True
+        try:
+            import orjson
+            _orjson = orjson
+        except ImportError:
+            _orjson = None
+    return _orjson
+
+
+def _dumps_value(structure):
+    """Serialize a JSON-safe structure for a VALUE (non-canonical). orjson when
+    available (returns bytes), else stdlib json (str); falls back to json for
+    inputs orjson rejects."""
+    oj = _get_orjson()
+    if oj is not None:
+        try:
+            return oj.dumps(structure)
+        except (TypeError, ValueError):
+            pass  # e.g. int > 64-bit — stdlib json handles it
+    return json.dumps(structure)
+
+
+def _loads_any(data):
+    """Parse JSON produced by either orjson or stdlib json (str or bytes).
+
+    Deliberately uses stdlib json.loads, NOT orjson.loads: orjson.loads
+    silently coerces integers beyond 64 bits to float (lossy), and stdlib
+    json.loads is both correct and C-accelerated. orjson's speed win is on the
+    write (dumps) side, where correctness is preserved by the big-int fallback."""
+    if isinstance(data, (bytes, bytearray)):
+        data = data.decode("utf-8")
+    return json.loads(data)
+
+
 @log.debug
 def serialize_custom(obj: Any, sort_keys: bool = False) -> str:
     serialized = _serialize_custom(obj)
-    # sort_keys=True gives canonical bytes: equal dicts (and equal kwargs) always
-    # serialize identically regardless of insertion order. Used for cache keys.
-    return json.dumps(serialized, sort_keys=sort_keys)
+    if sort_keys:
+        # canonical KEY path: stdlib json with sorted keys so equal keys hash
+        # identically regardless of insertion order OR whether orjson is present
+        return json.dumps(serialized, sort_keys=True)
+    # VALUE path: orjson-accelerated when available
+    return _dumps_value(serialized)
 
 def stuff(obj, data=None):
     return _serialize_custom(obj, data=data)
@@ -173,7 +223,7 @@ def _serialize_custom(obj: Any, data:Any=None) -> Any:
 ### Deserializing
 
 def deserialize_custom(serialized_str: str) -> Any:
-    return _deserialize_custom(json.loads(serialized_str))
+    return _deserialize_custom(_loads_any(serialized_str))
 
 def _deserialize_object_data(obj, obj_data: Any) -> Any:
     if _safe_mode_active():

--- a/hashstash/serializers/jsons.py
+++ b/hashstash/serializers/jsons.py
@@ -2,6 +2,7 @@
 # circular, and whether a name has landed in the package namespace yet
 # depends on import order (spawn workers + editable installs order imports
 # differently). Never rely on the star-chain for stdlib names.
+import datetime
 import json
 import pickle
 
@@ -62,6 +63,20 @@ def deserialize_msgpack(data):
     if isinstance(data, str):
         data = data.encode("utf-8")
     return msgpack.unpackb(data, timestamp=3, raw=False, strict_map_key=False)
+
+
+def serialize_cbor2(obj):
+    import cbor2
+    # cbor2 is DATA-only — it cannot encode functions/classes, which is
+    # exactly why it is safe to deserialize. timezone=... / datetime encoding
+    # is native in cbor2 (datetimes become CBOR tag 0/1).
+    return cbor2.dumps(obj, datetime_as_timestamp=True, timezone=datetime.timezone.utc)
+
+def deserialize_cbor2(data):
+    import cbor2
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return cbor2.loads(data)
 
 
 def serialize_jsonpickle(obj):

--- a/hashstash/serializers/serializer.py
+++ b/hashstash/serializers/serializer.py
@@ -7,6 +7,7 @@ def get_serializer(serializer: SERIALIZER_TYPES = DEFAULT_SERIALIZER):
         "jsonpickle": serialize_jsonpickle,
         "pickle": serialize_pickle,
         "msgpack": serialize_msgpack,
+        "cbor2": serialize_cbor2,
     }
 
     return serializer_dict.get(serializer)
@@ -17,6 +18,7 @@ def get_deserializer(serializer: SERIALIZER_TYPES = DEFAULT_SERIALIZER):
         "jsonpickle": deserialize_jsonpickle,
         "pickle": deserialize_pickle,
         "msgpack": deserialize_msgpack,
+        "cbor2": deserialize_cbor2,
     }
 
     return deserializer_dict.get(serializer)

--- a/hashstash/utils/wrappers.py
+++ b/hashstash/utils/wrappers.py
@@ -71,6 +71,8 @@ def stashed_result(
     stash: Optional["BaseHashStash"] = None,
     _force=False,
     _store_args=True,
+    _cache_exceptions=False,
+    _exception_ttl=None,
     **stash_kwargs,
 ):
     @log.debug
@@ -112,6 +114,8 @@ def stashed_result(
             # Extract _force from kwargs if present, otherwise use the default force value
             kwargs.setdefault('_force', _force)
             kwargs.setdefault('_store_args', _store_args)
+            kwargs.setdefault('_cache_exceptions', _cache_exceptions)
+            kwargs.setdefault('_exception_ttl', _exception_ttl)
 
             return stash.run(call_func, *args, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ redis = ["redis", "redis_dict"]
 mongo = ["pymongo"]
 msgpack = ["msgpack"]
 fsspec = ["fsspec"]
+duckdb = ["duckdb"]
 best = ["lmdb", "lz4"]
 lmdb = ["lmdb"]
 diskcache = ["diskcache"]
@@ -57,6 +58,7 @@ engines = [
     "redis", "redis_dict",
     "pymongo",
     "ultradict",
+    "duckdb",
 ]
 dev = [
   # engines
@@ -67,6 +69,7 @@ dev = [
   "redis", "redis_dict",
   "pymongo",
   "ultradict",
+  "duckdb",
 
   # serializers
   "jsonpickle",# "numpy", "pandas"
@@ -94,6 +97,7 @@ all = [
   "redis", "redis_dict",
   "pymongo",
   "ultradict",
+  "duckdb",
 
   # serializers
   "jsonpickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ fsspec = ["fsspec"]
 duckdb = ["duckdb"]
 best = ["lmdb", "lz4"]
 lmdb = ["lmdb"]
+# plyvel builds from source against the system LevelDB library (no binary
+# wheels), so it is intentionally NOT in the aggregate dev/all/engines extras —
+# it would break `pip install .[dev]` on machines without libleveldb-dev. The
+# leveldb engine tests importorskip cleanly when plyvel is absent.
 leveldb = ["plyvel"]
 diskcache = ["diskcache"]
 memory = ["ultradict"]
@@ -47,7 +51,6 @@ filebased = [
   "sqlitedict",
   "diskcache",
   "lmdb",
-  "plyvel",
   "ultradict",
 ]
 servers = [
@@ -56,7 +59,6 @@ servers = [
 engines = [
     "pandas", "polars", "numpy", "pyarrow","fastparquet",
     "lmdb",
-    "plyvel",
     "sqlitedict",
     "diskcache",
     "redis", "redis_dict",
@@ -68,7 +70,6 @@ dev = [
   # engines
   "pandas", "polars", "numpy", "pyarrow","fastparquet",
   "lmdb",
-  "plyvel",
   "sqlitedict",
   "diskcache",
   "redis", "redis_dict",
@@ -98,7 +99,6 @@ all = [
   # engines
   "pandas", "polars", "numpy", "pyarrow","fastparquet",
   "lmdb",
-  "plyvel",
   "sqlitedict",
   "diskcache",
   "redis", "redis_dict",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ msgpack = ["msgpack"]
 fsspec = ["fsspec"]
 best = ["lmdb", "lz4"]
 lmdb = ["lmdb"]
+rocksdb = ["plyvel"]
 diskcache = ["diskcache"]
 memory = ["ultradict"]
 
@@ -44,6 +45,7 @@ filebased = [
   "sqlitedict",
   "diskcache",
   "lmdb",
+  "plyvel",
   "ultradict",
 ]
 servers = [
@@ -52,6 +54,7 @@ servers = [
 engines = [
     "pandas", "polars", "numpy", "pyarrow","fastparquet",
     "lmdb",
+    "plyvel",
     "sqlitedict",
     "diskcache",
     "redis", "redis_dict",
@@ -62,6 +65,7 @@ dev = [
   # engines
   "pandas", "polars", "numpy", "pyarrow","fastparquet",
   "lmdb",
+  "plyvel",
   "sqlitedict",
   "diskcache",
   "redis", "redis_dict",
@@ -89,6 +93,7 @@ all = [
   # engines
   "pandas", "polars", "numpy", "pyarrow","fastparquet",
   "lmdb",
+  "plyvel",
   "sqlitedict",
   "diskcache",
   "redis", "redis_dict",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ sqlite = ["sqlitedict"]
 redis = ["redis", "redis_dict"]
 mongo = ["pymongo"]
 msgpack = ["msgpack"]
+cbor2 = ["cbor2"]
 fsspec = ["fsspec"]
 best = ["lmdb", "lz4"]
 lmdb = ["lmdb"]
@@ -72,6 +73,7 @@ dev = [
   "jsonpickle",# "numpy", "pandas"
   "orjson",
   "msgpack",
+  "cbor2",
 
   # compressers
   "lz4",
@@ -99,6 +101,7 @@ all = [
   "jsonpickle",
   "orjson",
   "msgpack",
+  "cbor2",
 
   # Compressers
   "lz4",

--- a/tests/test_cbor2.py
+++ b/tests/test_cbor2.py
@@ -1,0 +1,58 @@
+"""The cbor2 serializer (data-only, fast, compact — mirrors msgpack)."""
+import datetime
+
+import pytest
+
+from hashstash import HashStash, deserialize, serialize
+
+
+cbor2 = pytest.importorskip("cbor2")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"a": 1, "b": [1, 2, 3]},
+        [1, 2.5, "three", True, None],
+        {"nested": {"deep": {"list": [1, 2, {"x": "y"}]}}},
+        b"raw bytes",
+        "unicode: ☃",
+        {"ints": list(range(100))},
+        datetime.datetime(2020, 1, 1, 12, 0, tzinfo=datetime.timezone.utc),
+    ],
+)
+def test_cbor2_roundtrip(value):
+    blob = serialize(value, serializer="cbor2")
+    assert isinstance(blob, (bytes, str))
+    assert deserialize(blob, serializer="cbor2") == value
+
+
+def test_cbor2_datetime(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"), serializer="cbor2")
+    dt = datetime.datetime(2020, 1, 1, 12, 0, tzinfo=datetime.timezone.utc)
+    stash["when"] = dt
+    assert stash["when"] == dt
+
+
+def test_cbor2_stash_end_to_end(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"), serializer="cbor2")
+    assert stash.serializer == "cbor2"
+    stash["data"] = {"user": "alice", "scores": [1, 2, 3]}
+    assert stash["data"] == {"user": "alice", "scores": [1, 2, 3]}
+
+
+def test_cbor2_is_a_working_serializer():
+    from hashstash.config import get_working_serializers
+
+    assert "cbor2" in get_working_serializers()
+
+
+def test_cbor2_compact_vs_hashstash(tmp_path):
+    """cbor2 should produce a smaller blob than the JSON-based custom serializer
+    for plain data (it's a binary format)."""
+    value = {"records": [{"id": i, "name": f"item{i}"} for i in range(200)]}
+    cb = serialize(value, serializer="cbor2")
+    hs = serialize(value, serializer="hashstash")
+    cb_len = len(cb if isinstance(cb, bytes) else cb.encode())
+    hs_len = len(hs if isinstance(hs, bytes) else hs.encode())
+    assert cb_len < hs_len

--- a/tests/test_duckdb_engine.py
+++ b/tests/test_duckdb_engine.py
@@ -1,0 +1,117 @@
+"""DuckDBHashStash: key-value engine backed by a single DuckDB BLOB table."""
+import time
+
+import pytest
+
+pytest.importorskip("duckdb")
+
+from hashstash import HashStash
+
+
+@pytest.fixture
+def stash(tmp_path):
+    s = HashStash(engine="duckdb", root_dir=f"{tmp_path}/duckcache")
+    s.clear()
+    yield s
+    s.clear()
+
+
+def test_roundtrip_dict(stash):
+    stash["k"] = {"a": [1, 2, 3], "nested": {"x": True}}
+    assert stash["k"] == {"a": [1, 2, 3], "nested": {"x": True}}
+
+
+def test_roundtrip_list_and_nested(stash):
+    stash["lst"] = [1, "two", 3.0, [4, 5]]
+    assert stash["lst"] == [1, "two", 3.0, [4, 5]]
+    stash["deep"] = {"a": {"b": {"c": [{"d": 1}]}}}
+    assert stash["deep"] == {"a": {"b": {"c": [{"d": 1}]}}}
+
+
+def test_roundtrip_bytes(stash):
+    stash["raw"] = b"\x00\x01\x02binary\xff"
+    assert stash["raw"] == b"\x00\x01\x02binary\xff"
+
+
+def test_contains_and_len(stash):
+    assert len(stash) == 0
+    stash["a"] = 1
+    stash["b"] = 2
+    assert "a" in stash
+    assert "missing" not in stash
+    assert len(stash) == 2
+
+
+def test_keys_values_items(stash):
+    stash["a"] = 10
+    stash["b"] = 20
+    assert sorted(stash.keys()) == ["a", "b"]
+    assert sorted(stash.values()) == [10, 20]
+    assert sorted(stash.items()) == [("a", 10), ("b", 20)]
+
+
+def test_delete(stash):
+    stash["k"] = "v"
+    del stash["k"]
+    assert "k" not in stash
+    with pytest.raises(KeyError):
+        del stash["k"]
+
+
+def test_delete_missing_raises(stash):
+    with pytest.raises(KeyError):
+        stash.delete("never-set")
+
+
+def test_overwrite(stash):
+    stash["k"] = 1
+    stash["k"] = 2
+    assert stash["k"] == 2
+    assert len(stash) == 1
+
+
+def test_append_mode(tmp_path):
+    stash = HashStash(
+        engine="duckdb", root_dir=f"{tmp_path}/appendcache", append_mode=True
+    )
+    stash.clear()
+    stash["k"] = 1
+    stash["k"] = 2
+    assert stash.get_all("k") == [1, 2]
+    assert len(stash) == 1
+
+
+def test_persists_across_instances(tmp_path):
+    root = f"{tmp_path}/persistcache"
+    a = HashStash(engine="duckdb", root_dir=root)
+    a.clear()
+    a["k"] = "durable"
+    a.close()
+    b = HashStash(engine="duckdb", root_dir=root)
+    assert b["k"] == "durable"
+    b.clear()
+
+
+def test_ttl_expiry(tmp_path):
+    stash = HashStash(engine="duckdb", root_dir=f"{tmp_path}/ttlcache", ttl=0.3)
+    stash.clear()
+    stash["k"] = "v"
+    time.sleep(0.6)
+    assert stash.get("k") is None
+    assert "k" not in stash
+    stash.clear()
+
+
+def test_clear(stash):
+    stash["a"] = 1
+    stash["b"] = 2
+    assert len(stash) == 2
+    stash.clear()
+    assert len(stash) == 0
+    assert "a" not in stash
+
+
+def test_duckdb_in_working_engines():
+    from hashstash.config import get_working_engines
+
+    assert "duckdb" in get_working_engines()

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -535,7 +535,14 @@ class TestHashStash:
 
 class TestHashStashFactory:
     def test_engine_selection(self):
+        from hashstash.config import get_working_engines
+
+        working = get_working_engines()
         for engine in ENGINES:
+            # engines whose backing package isn't installed (e.g. rocksdb without
+            # plyvel) can't be constructed here; skip rather than hard-fail
+            if engine not in working:
+                continue
             stash = HashStash(engine=engine)
             assert stash.engine == engine
 

--- a/tests/test_exception_caching.py
+++ b/tests/test_exception_caching.py
@@ -1,0 +1,174 @@
+"""Exception / negative caching: cache function failures so they aren't
+re-executed, opt-in via _cache_exceptions (run/@stashed_result) or
+cache_exceptions (get_set)."""
+import time
+
+import pytest
+
+from hashstash import HashStash, stashed_result
+from hashstash.engines.base import HashStashCachedError
+
+
+# module-level (closure-free) so cache identity is stable across calls; the call
+# log lives in a module global that isn't part of the function's identity
+_calls = []
+
+
+def _always_fails(x):
+    _calls.append(x)
+    raise ValueError(f"boom-{x}")
+
+
+def _fails_then(x):
+    _calls.append(x)
+    raise KeyError("missing")
+
+
+def setup_function():
+    _calls.clear()
+
+
+# --- default behaviour: failures are NOT cached -------------------------------
+
+
+def test_without_flag_reexecutes_on_failure(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 1)
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 1)
+    assert len(_calls) == 2  # re-executed each time
+
+
+# --- opt-in: failures ARE cached and re-raised --------------------------------
+
+
+def test_cached_exception_not_reexecuted(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    with pytest.raises(ValueError, match="boom-1"):
+        stash.run(_always_fails, 1, _cache_exceptions=True)
+    # second call re-raises the cached exception WITHOUT calling the function
+    with pytest.raises(ValueError, match="boom-1"):
+        stash.run(_always_fails, 1, _cache_exceptions=True)
+    assert len(_calls) == 1
+
+
+def test_cached_exception_preserves_type(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    with pytest.raises(KeyError):
+        stash.run(_fails_then, 1, _cache_exceptions=True)
+    # a caller catching the ORIGINAL type still catches the cached one
+    try:
+        stash.run(_fails_then, 1, _cache_exceptions=True)
+        assert False, "should have raised"
+    except KeyError:
+        pass
+    assert len(_calls) == 1
+
+
+def test_cached_exception_expires(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 2, _cache_exceptions=True, _exception_ttl=0.3)
+    time.sleep(0.6)
+    # expired -> recomputed (raises again, function called a second time)
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 2, _cache_exceptions=True, _exception_ttl=0.3)
+    assert len(_calls) == 2
+
+
+def test_force_bypasses_cached_exception(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 3, _cache_exceptions=True)
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 3, _cache_exceptions=True, _force=True)
+    assert len(_calls) == 2  # _force re-executes
+
+
+def _flaky(x):
+    # fails the first time, succeeds after the cached exception is cleared
+    _calls.append(x)
+    if len(_calls) == 1:
+        raise RuntimeError("first-call-fails")
+    return x * 10
+
+
+def test_recovers_after_exception_ttl(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    with pytest.raises(RuntimeError):
+        stash.run(_flaky, 5, _cache_exceptions=True, _exception_ttl=0.3)
+    time.sleep(0.6)
+    assert stash.run(_flaky, 5, _cache_exceptions=True, _exception_ttl=0.3) == 50
+    # and now the success is cached
+    assert stash.run(_flaky, 5, _cache_exceptions=True) == 50
+    assert len(_calls) == 2
+
+
+# --- @stashed_result and get_set ---------------------------------------------
+
+
+def test_stashed_result_cache_exceptions(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+
+    @stash.stashed_result
+    def f(x):
+        _calls.append(x)
+        raise ValueError("nope")
+
+    with pytest.raises(ValueError):
+        f(1, _cache_exceptions=True)
+    with pytest.raises(ValueError):
+        f(1, _cache_exceptions=True)
+    assert len(_calls) == 1
+
+
+def test_get_set_cache_exceptions(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+
+    def setter():
+        _calls.append(1)
+        raise RuntimeError("setter failed")
+
+    with pytest.raises(RuntimeError):
+        stash.get_set("k", setter, cache_exceptions=True)
+    with pytest.raises(RuntimeError):
+        stash.get_set("k", setter, cache_exceptions=True)
+    assert len(_calls) == 1
+
+
+# --- safe mode compatibility --------------------------------------------------
+
+
+def test_cached_exception_works_under_safe_mode(tmp_path):
+    """The cached-exception marker is plain data, so negative caching works even
+    with safe=True (unlike caching a serialized exception object would)."""
+    stash = HashStash(root_dir=str(tmp_path / "c"), safe=True)
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 7, _cache_exceptions=True)
+    with pytest.raises(ValueError):
+        stash.run(_always_fails, 7, _cache_exceptions=True)
+    assert len(_calls) == 1
+
+
+# --- non-importable exception falls back gracefully ---------------------------
+
+
+class _LocalError(Exception):
+    pass
+
+
+def _raise_local(x):
+    _calls.append(x)
+    raise _LocalError("local")
+
+
+def test_non_importable_exception_falls_back(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    with pytest.raises(_LocalError):
+        stash.run(_raise_local, 1, _cache_exceptions=True)
+    # the locally-defined class can't be reimported in-process by qualname, so
+    # the cached re-raise falls back to HashStashCachedError (carrying the info)
+    with pytest.raises((_LocalError, HashStashCachedError)):
+        stash.run(_raise_local, 1, _cache_exceptions=True)
+    assert len(_calls) == 1

--- a/tests/test_graph_indexing.py
+++ b/tests/test_graph_indexing.py
@@ -1,0 +1,123 @@
+"""GraphStash rel-index: edges_where(rel=...) narrows the scan via a secondary
+index, and stays correct across adds, bulk loads, batches, and removes."""
+import pytest
+
+from hashstash import HashStash
+
+
+@pytest.fixture
+def graph(tmp_path):
+    return HashStash(root_dir=str(tmp_path / "g")).graph()
+
+
+def _brute_edges_where(g, **kwargs):
+    """Reference implementation: full scan, no index — for parity checks."""
+    from hashstash.graph import _match
+
+    out = []
+    for src in g._out_keys():
+        for dst, rel, props in g._get_out(src):
+            sp = g._get_node_props(src) or {}
+            dp = g._get_node_props(dst) or {}
+            if _match(sp, dp, rel, props, kwargs):
+                out.append((src, dst, rel, dict(props)))
+    return out
+
+
+def _norm(edges):
+    return sorted((s, d, r, tuple(sorted(p.items()))) for s, d, r, p in edges)
+
+
+def test_index_matches_bruteforce_on_rel(graph):
+    graph.add_edge("a", "b", rel="knows", w=1)
+    graph.add_edge("a", "c", rel="knows", w=5)
+    graph.add_edge("a", "d", rel="likes", w=2)
+    graph.add_edge("b", "c", rel="knows", w=9)
+    for rel in ("knows", "likes", "nope"):
+        assert _norm(graph.edges_where(rel=rel)) == _norm(_brute_edges_where(graph, rel=rel))
+
+
+def test_index_actually_narrows_sources(graph):
+    graph.add_edge("hub", "x", rel="likes")
+    for i in range(20):
+        graph.add_edge(f"n{i}", f"m{i}", rel="knows")
+    # only 'hub' has a 'likes' edge; the index must return just that source
+    assert graph._rel_sources("likes") == {"hub"}
+    assert len(graph.edges_where(rel="likes")) == 1
+
+
+def test_rel_none_indexed(graph):
+    graph.add_edge("a", "b")            # rel None
+    graph.add_edge("a", "c", rel="k")
+    hits = graph.edges_where(rel=None)
+    assert [(s, d) for s, d, r, p in hits] == [("a", "b")]
+
+
+def test_index_maintained_on_bulk(graph):
+    graph.add_edges_bulk([("a", "b", "r1", {}), ("c", "d", "r2", {}), ("a", "e", "r1", {})])
+    assert graph._rel_sources("r1") == {"a"}
+    assert graph._rel_sources("r2") == {"c"}
+    assert len(graph.edges_where(rel="r1")) == 2
+
+
+def test_index_maintained_in_batch(graph):
+    with graph.batch():
+        for i in range(10):
+            graph.add_edge("s", f"t{i}", rel="e")
+    assert graph._rel_sources("e") == {"s"}
+    assert len(graph.edges_where(rel="e")) == 10
+
+
+def test_index_rebuilds_after_remove_edge(graph):
+    graph.add_edge("a", "b", rel="knows")
+    graph.add_edge("a", "c", rel="likes")
+    assert len(graph.edges_where(rel="knows")) == 1  # builds index
+    graph.remove_edge("a", "b", rel="knows")
+    # index invalidated on remove; next query rebuilds and reflects the removal
+    assert graph.edges_where(rel="knows") == []
+    assert len(graph.edges_where(rel="likes")) == 1
+
+
+def test_index_rebuilds_after_remove_node(graph):
+    graph.add_edge("a", "b", rel="knows")
+    graph.add_edge("c", "b", rel="knows")
+    assert len(graph.edges_where(rel="knows")) == 2
+    graph.remove_node("a")
+    assert _norm(graph.edges_where(rel="knows")) == _norm(_brute_edges_where(graph, rel="knows"))
+    assert len(graph.edges_where(rel="knows")) == 1
+
+
+def test_index_reflects_lazy_build_across_instances(tmp_path):
+    root = str(tmp_path / "g")
+    g1 = HashStash(root_dir=root).graph()
+    g1.add_edge("a", "b", rel="knows")
+    g1.add_edge("a", "c", rel="likes")
+    # fresh instance builds its index from disk on first query
+    g2 = HashStash(root_dir=root).graph()
+    assert len(g2.edges_where(rel="knows")) == 1
+    assert g2._rel_sources("likes") == {"a"}
+
+
+def test_rels_and_edges_with_rel(graph):
+    graph.add_edge("a", "b", rel="knows")
+    graph.add_edge("a", "c")  # None
+    graph.add_edge("b", "c", rel="likes")
+    assert graph.rels() == [None, "knows", "likes"]
+    assert len(graph.edges_with_rel("knows")) == 1
+    assert len(graph.edges_with_rel(None)) == 1
+
+
+def test_rel_index_with_extra_predicates(graph):
+    graph.add_edge("a", "b", rel="knows", weight=5)
+    graph.add_edge("a", "c", rel="knows", weight=1)
+    graph.add_edge("a", "d", rel="likes", weight=9)
+    hits = graph.edges_where(rel="knows", weight__gte=3)
+    assert [(s, d) for s, d, r, p in hits] == [("a", "b")]
+
+
+def test_clear_resets_index(graph):
+    graph.add_edge("a", "b", rel="knows")
+    assert len(graph.edges_where(rel="knows")) == 1
+    graph.clear()
+    assert graph.edges_where(rel="knows") == []
+    assert graph.rels() == []

--- a/tests/test_lmdb_autogrow.py
+++ b/tests/test_lmdb_autogrow.py
@@ -1,0 +1,75 @@
+"""LMDB auto-grow on MapFullError.
+
+LMDB has a fixed map_size and raises lmdb.MapFullError once the map fills. The
+store used to wedge; now write transactions double self.map_size, call
+env.set_mapsize on the shared environment, and retry — so writes keep succeeding
+past the initial map_size.
+"""
+import pytest
+
+pytest.importorskip("lmdb")
+
+from hashstash import HashStash
+
+
+def test_lmdb_autogrows_on_mapfull(tmp_path):
+    # 64 KB is tiny for LMDB — a few hundred KB of values forces several grows.
+    initial_map_size = 1024 * 64
+    stash = HashStash(
+        engine="lmdb",
+        root_dir=str(tmp_path / "m"),
+        map_size=initial_map_size,
+    )
+    stash.clear()
+    assert stash.map_size == initial_map_size
+
+    n = 300
+    # ~1.5 KB per value -> ~450 KB of data, well past a 64 KB map.
+    expected = {f"key-{i}": f"{i}:" + ("x" * 1500) for i in range(n)}
+
+    for k, v in expected.items():
+        stash[k] = v  # must not raise MapFullError; grows the map instead
+
+    # The map must have grown past where it started.
+    assert stash.map_size > initial_map_size
+
+    # Every write is durable and reads back byte-for-byte.
+    for k, v in expected.items():
+        assert stash[k] == v
+    assert len(stash) == n
+
+    stash.close()
+
+
+def test_lmdb_grown_map_persists_for_new_instance(tmp_path):
+    """After a grow, a fresh stash on the same path keeps reading the data and
+    can keep writing — the grown env is shared per path (issue #9)."""
+    root = str(tmp_path / "m2")
+    initial_map_size = 1024 * 64
+    a = HashStash(engine="lmdb", root_dir=root, map_size=initial_map_size)
+    a.clear()
+
+    payload = "y" * 1500
+    for i in range(300):
+        a[f"k{i}"] = payload
+    assert a.map_size > initial_map_size
+
+    # Second instance on the same path shares the grown environment.
+    b = HashStash(engine="lmdb", root_dir=root, map_size=initial_map_size)
+    assert b["k0"] == payload
+    assert b["k299"] == payload
+    b["extra"] = payload  # still writable through the shared, grown env
+    assert a["extra"] == payload
+    a.close()
+
+
+def test_lmdb_grow_respects_cap(tmp_path):
+    """Growth stops at max_map_size and re-raises rather than looping forever."""
+    import lmdb
+
+    stash = HashStash(engine="lmdb", root_dir=str(tmp_path / "m3"), map_size=1024 * 64)
+    stash.clear()
+    stash.max_map_size = stash.map_size  # already at the cap -> no room to grow
+    with pytest.raises(lmdb.MapFullError):
+        stash._grow_map()
+    stash.close()

--- a/tests/test_orjson_accel.py
+++ b/tests/test_orjson_accel.py
@@ -1,0 +1,101 @@
+"""orjson value acceleration: values may use orjson, but cache KEYS must stay
+stdlib-json canonical so hashes never depend on whether orjson is installed."""
+import json
+
+import pytest
+
+from hashstash import HashStash, deserialize, serialize
+from hashstash.serializers import custom
+from hashstash.serializers.custom import _serialize_custom, serialize_custom
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"a": 1, "b": [1, 2, 3]},
+        {"nested": {"x": [1, {"y": 2}]}},
+        [1, 2.5, "three", True, None],
+        {"unicode": "☃", "bytes-ish": "plain"},
+        {1: "int-key", (2, 3): "tuple-key"},  # goes through the tagged dict form
+        {"big": 2 ** 70},  # orjson rejects >64-bit ints -> must fall back to json
+        {"set": {1, 2, 3}},
+    ],
+)
+def test_value_roundtrips(value, tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    stash["k"] = value
+    assert stash["k"] == value
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        {"a": 1, "b": 2},
+        {"b": 2, "a": 1},
+        (["fn"], {"y": 1, "x": 2}),
+        {1: "x", 2: "y"},
+        {"deep": {"z": 9, "a": [3, 2, 1]}},
+    ],
+)
+def test_key_bytes_are_json_canonical(key):
+    """The sort_keys path must be byte-identical to pure stdlib json — this is
+    what guarantees a key hashes the same whether or not orjson is installed."""
+    expected = json.dumps(_serialize_custom(key), sort_keys=True)
+    got = serialize_custom(key, sort_keys=True)
+    assert got == expected
+    assert isinstance(got, str)  # never orjson bytes for keys
+
+
+def test_orjson_is_actually_used_for_values():
+    """When orjson is installed, value serialization returns bytes (orjson),
+    while keys stay str (json)."""
+    pytest.importorskip("orjson")
+    assert custom._get_orjson() is not None
+    value_blob = serialize_custom({"a": 1}, sort_keys=False)
+    assert isinstance(value_blob, bytes)  # orjson path
+    key_blob = serialize_custom({"a": 1}, sort_keys=True)
+    assert isinstance(key_blob, str)  # json path
+
+
+def test_key_stable_without_orjson(monkeypatch):
+    """Simulate orjson being absent: key bytes must be unchanged."""
+    key = {"b": 2, "a": 1, "c": [3, 1, 2]}
+    with_orjson = serialize_custom(key, sort_keys=True)
+    # force the no-orjson path
+    monkeypatch.setattr(custom, "_orjson", None)
+    monkeypatch.setattr(custom, "_orjson_checked", True)
+    without_orjson = serialize_custom(key, sort_keys=True)
+    assert with_orjson == without_orjson
+
+
+def test_value_written_with_orjson_reads_without(monkeypatch, tmp_path):
+    """A value serialized via orjson must be readable via the stdlib path
+    (cross-compatibility) and vice versa."""
+    value = {"records": [{"id": i} for i in range(20)], "flag": True}
+    blob = serialize(value, serializer="hashstash")  # orjson path (bytes)
+    # now pretend orjson is gone and deserialize
+    monkeypatch.setattr(custom, "_orjson", None)
+    monkeypatch.setattr(custom, "_orjson_checked", True)
+    assert deserialize(blob, serializer="hashstash") == value
+
+
+def test_big_int_value_falls_back_cleanly(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    stash["k"] = {"n": 12345678901234567890123456789}  # way over 64-bit
+    assert stash["k"] == {"n": 12345678901234567890123456789}
+
+
+def test_encode_key_deterministic_across_orjson_state(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    k1 = stash.encode_key({"a": 1, "b": 2})
+    k2 = stash.encode_key({"b": 2, "a": 1})
+    assert k1 == k2  # canonical regardless of insertion order / orjson
+
+
+def test_get_as_string_returns_str(tmp_path):
+    """get(as_string=True) must return str even though orjson value serialization
+    produces bytes."""
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    stash["k"] = {"a": [1, 2, 3]}
+    result = stash.get("k", as_string=True)
+    assert isinstance(result, str)

--- a/tests/test_rocksdb_engine.py
+++ b/tests/test_rocksdb_engine.py
@@ -1,0 +1,103 @@
+"""RocksDBHashStash: LevelDB-backed key-value engine via plyvel."""
+import time
+
+import pytest
+
+# plyvel needs the system LevelDB C library; skip cleanly if it isn't installed
+plyvel = pytest.importorskip("plyvel")
+
+from hashstash import HashStash
+
+
+@pytest.fixture
+def stash(tmp_path):
+    s = HashStash(engine="rocksdb", root_dir=str(tmp_path / "rockscache"))
+    s.clear()
+    yield s
+    s.clear()
+
+
+def test_roundtrip(stash):
+    stash["k"] = {"a": [1, 2, 3], "nested": {"x": True}}
+    assert stash["k"] == {"a": [1, 2, 3], "nested": {"x": True}}
+
+
+def test_contains_and_len(stash):
+    assert len(stash) == 0
+    stash["a"] = 1
+    stash["b"] = 2
+    assert "a" in stash
+    assert "missing" not in stash
+    assert len(stash) == 2
+
+
+def test_keys_values_items(stash):
+    stash["a"] = 10
+    stash["b"] = 20
+    assert sorted(stash.keys()) == ["a", "b"]
+    assert sorted(stash.values()) == [10, 20]
+    assert sorted(stash.items()) == [("a", 10), ("b", 20)]
+
+
+def test_delete(stash):
+    stash["k"] = "v"
+    del stash["k"]
+    assert "k" not in stash
+    with pytest.raises(KeyError):
+        del stash["k"]
+
+
+def test_overwrite(stash):
+    stash["k"] = 1
+    stash["k"] = 2
+    assert stash["k"] == 2
+    assert len(stash) == 1
+
+
+def test_append_mode(tmp_path):
+    stash = HashStash(
+        engine="rocksdb",
+        root_dir=str(tmp_path / "appendcache"),
+        append_mode=True,
+    )
+    stash.clear()
+    stash["k"] = 1
+    stash["k"] = 2
+    assert stash.get_all("k") == [1, 2]
+    stash.clear()
+
+
+def test_persists_across_instances(tmp_path):
+    root = str(tmp_path / "persistcache")
+    a = HashStash(engine="rocksdb", root_dir=root)
+    a.clear()
+    a["k"] = "durable"
+    a.close()  # drop the process-global handle so b reopens from disk
+    b = HashStash(engine="rocksdb", root_dir=root)
+    assert b["k"] == "durable"
+    b.clear()
+
+
+def test_ttl_expiry(tmp_path):
+    stash = HashStash(engine="rocksdb", root_dir=str(tmp_path / "ttlcache"), ttl=0.2)
+    stash.clear()
+    stash["k"] = "v"
+    assert stash["k"] == "v"
+    time.sleep(0.3)
+    assert stash.get("k") is None
+    stash.clear()
+
+
+def test_clear(stash):
+    stash["a"] = 1
+    stash["b"] = 2
+    assert len(stash) == 2
+    stash.clear()
+    assert len(stash) == 0
+    assert "a" not in stash
+
+
+def test_rocksdb_in_working_engines():
+    from hashstash.config import get_working_engines
+
+    assert "rocksdb" in get_working_engines()

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -27,10 +27,10 @@ def require_code_serialization(serializer_type):
 
 def require_rich_types(serializer_type):
     """Skip for data-only serializers that don't handle numpy/pandas/Path/sets
-    (msgpack is a fixed data format; only hashstash/pickle/jsonpickle round-trip
-    these arbitrary Python objects)."""
-    if serializer_type == "msgpack":
-        pytest.skip("msgpack is data-only; numpy/pandas/Path not supported")
+    (msgpack/cbor2 are fixed data formats; only hashstash/pickle/jsonpickle
+    round-trip these arbitrary Python objects)."""
+    if serializer_type in ("msgpack", "cbor2"):
+        pytest.skip(f"{serializer_type} is data-only; numpy/pandas/Path not supported")
 
 @pytest.fixture
 def cache(serializer_type, tmp_path):


### PR DESCRIPTION
Delivers the **entire remaining roadmap** as one coherent v0.9.0 — seven features, integrated onto one branch with the full suite green (**881 passed, 121 skipped**, every optional dep present). Executed as a hybrid fan-out: three subtle features by the main session, four mechanical ones by parallel sub-agents in isolated worktrees, all reviewed and integrated here.

Individual feature branches remain pushed (`feat/graph-indexing`, `feat/exception-caching`, `feat/orjson-accel`, `feat/lmdb-autogrow`, `feat/cbor2`, `feat/duckdb-engine`, `feat/leveldb-…`) if you want to review any feature in isolation; this PR is their conflict-resolved union.

## Features

**GraphStash rel index** — `edges_where(rel=...)` was an O(V+E) full scan; now a secondary index (`rel → source nodes`) makes it visit only sources with that rel. Built lazily, maintained on add/bulk/batch, rebuilt after removes. New `rels()` / `edges_with_rel()`. Correctness verified against a brute-force reference across every mutation path.

**Exception / negative caching** — `run`/`@stashed_result` (`_cache_exceptions`, `_exception_ttl`) and `get_set` (`cache_exceptions`, `exception_ttl`) cache failures so an expensive raising call isn't re-run. Original exception type preserved (`except OriginalError` still catches); stored as a plain-data marker so it works under `safe=True` and carries its own TTL; `_force` bypasses.

**orjson value acceleration** — orjson dumps the value path when installed. Keys stay stdlib-json canonical (install-independent hashes); reads stay stdlib `json.loads` (orjson.loads is lossy on >64-bit ints); big-int values fall back to json. Honest scope: ~10x on the dumps *step* but ~1.2x end-to-end (the recursive `_serialize_custom` dominates — noted as a follow-on lever in ROADMAP).

**LMDB auto-grow** *(sub-agent)* — writes grow the map on `MapFullError` (double, capped at 256 GB, retry) instead of wedging, via `set_mapsize` on the shared registry env.

**DuckDB engine** *(sub-agent)* — `engine="duckdb"`, an embedded-SQL key-value store (BLOB key/value table), full KV + append_mode + ttl coverage.

**LevelDB engine** *(sub-agent, renamed from "rocksdb")* — `engine="leveldb"` via plyvel; an LSM store with no fixed size to pre-allocate. Renamed to match its actual backend. (The sub-agent even worked around a Homebrew-leveldb RTTI issue to test plyvel locally.)

**cbor2 serializer** *(sub-agent)* — `serializer="cbor2"`, fast/compact/data-only, pairs with `safe=True` like msgpack.

## Notes
- `.claude/worktrees/` is now gitignored (sub-agent worktrees).
- Version → 0.9.0. Per the tag-based `cd.yml`, merging this publishes nothing; cut the release later with `git tag v0.9.0 && git push --tags`.
- Optional deps added to extras: `duckdb`, `leveldb` (plyvel), `cbor2`. plyvel on macOS needs a from-source leveldb built with RTTI (documented in the agent's work); Linux CI's `libleveldb-dev` works out of the box, and the tests `importorskip` cleanly when it's absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
