### PR TITLE
perf: JSON-native fast-path + inf/nan corruption fix (tier 3)

### DIFF
--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -145,6 +145,45 @@ def _loads_any(data):
     return json.loads(data)
 
 
+def _is_json_native(obj):
+    """True if a VALUE can be dumped directly by json/orjson and read back
+    identically, letting serialize_custom skip the recursive _serialize_custom
+    rebuild entirely — the biggest serialization cost for JSON-shaped payloads.
+
+    EXACT types only (`type(obj) is X`, not isinstance): subclasses take the
+    full path, so bool/IntEnum/OrderedDict/defaultdict/namedtuple and friends
+    never slip through with different-from-full-path semantics.
+
+    Rejected (they serialize DIFFERENTLY via _serialize_custom, so a direct dump
+    would corrupt the round-trip):
+      - tuple    -> full path tags it; a direct dump becomes a JSON array (list)
+      - set/bytes/... -> need their custom serializers
+      - dict with a non-str or reserved-marker key -> full path uses the tagged
+        '__pytype__: dict' form; a direct dump would either coerce int keys to
+        str or be misread as an object marker on load
+
+    Big ints and non-finite floats are NOT rejected here: _dumps_value falls
+    back to stdlib json.dumps(obj) for them, which for a native obj is byte-for-
+    byte what the full path would produce."""
+    t = type(obj)
+    if obj is None or t is bool or t is int or t is str:
+        return True
+    if t is float:
+        # finite floats dump fine; inf/nan need the tagged form (orjson emits
+        # null for them), so route those through the full path
+        return obj == obj and obj != float("inf") and obj != float("-inf")
+    if t is list:
+        return all(_is_json_native(v) for v in obj)
+    if t is dict:
+        for k, v in obj.items():
+            if type(k) is not str or k in RESERVED_DICT_KEYS:
+                return False
+            if not _is_json_native(v):
+                return False
+        return True
+    return False
+
+
 # NOTE: serialize_custom / _serialize_custom are intentionally NOT decorated
 # with @log.debug. _serialize_custom recurses once per node of the value tree
 # (millions of calls on a large payload), and the log-wrapper's per-call
@@ -152,6 +191,11 @@ def _loads_any(data):
 # (measured 1.5x speedup from removing it). Tracing lives at the serialize()/
 # deserialize() boundary in serializer.py, which fires once per operation.
 def serialize_custom(obj: Any, sort_keys: bool = False) -> str:
+    # VALUE fast-path: a purely JSON-native value dumps identically without the
+    # recursive _serialize_custom rebuild — the dominant serialization cost. Only
+    # for values (not the canonical key path): keys stay on the audited full path.
+    if not sort_keys and _is_json_native(obj):
+        return _dumps_value(obj)
     serialized = _serialize_custom(obj)
     if sort_keys:
         # canonical KEY path: stdlib json with sorted keys so equal keys hash
@@ -176,7 +220,15 @@ def _serialize_custom(obj: Any, data:Any=None) -> Any:
         }
 
 
-    if isinstance(obj, (str, int, float, bool)):
+    if isinstance(obj, float):
+        # non-finite floats round-trip through a tagged form: orjson emits null
+        # for inf/nan (silent data loss) and stdlib json emits non-standard
+        # Infinity/NaN. The tag survives any JSON backend.
+        if obj != obj or obj == float("inf") or obj == float("-inf"):
+            return {'__pytype__': 'float', '__val__': repr(obj)}
+        return obj
+
+    if isinstance(obj, (str, int, bool)):
         return obj
 
     if isinstance(obj, dict):
@@ -293,6 +345,9 @@ def _deserialize_custom(data: Any) -> Any:
                 _deserialize_custom(k): _deserialize_custom(v)
                 for k, v in data['__items__']
             }
+
+        if pytype == 'float':
+            return float(data['__val__'])
 
         if pytype == 'instance':
             if _safe_mode_active():

--- a/tests/test_serializer_fastpath.py
+++ b/tests/test_serializer_fastpath.py
@@ -1,0 +1,131 @@
+"""Tier 3: JSON-native fast-path in serialize_custom. The fast-path must be
+byte-identical to the full path and round-trip every type correctly, including
+the non-finite-float fix it surfaced."""
+import math
+from collections import OrderedDict, namedtuple
+from enum import IntEnum
+
+import pytest
+
+from hashstash import HashStash, deserialize, serialize
+from hashstash.serializers.custom import (
+    _dumps_value,
+    _is_json_native,
+    _serialize_custom,
+    deserialize_custom,
+    serialize_custom,
+)
+
+
+def _full_path(obj):
+    """What serialize_custom would produce WITHOUT the fast-path."""
+    return _dumps_value(_serialize_custom(obj))
+
+
+def _nan_aware_eq(a, b):
+    if isinstance(a, float) and isinstance(b, float):
+        return a == b or (math.isnan(a) and math.isnan(b))
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(_nan_aware_eq(x, y) for x, y in zip(a, b))
+    if isinstance(a, dict) and isinstance(b, dict):
+        return a.keys() == b.keys() and all(_nan_aware_eq(a[k], b[k]) for k in a)
+    return type(a) is type(b) and a == b
+
+
+NATIVE = [
+    None, True, False, 0, 42, -7, 3.14, -0.5, "", "str", "☃",
+    [], {}, [1, 2, 3], {"a": 1, "b": [1, 2, {"c": None}]},
+    {"deep": {"list": [1, "two", 3.0, False, None]}},
+    {"big": 2 ** 70},                    # big int -> json fallback, still native-shaped
+    [1.0, 2.5, {"x": [True, None]}],
+]
+
+# non-native values that DO round-trip to the exact same type
+NONNATIVE_ROUNDTRIP = [
+    (1, 2, 3),
+    {1: "one", 2: "two"},
+    {(1, 2): "tuple-key"},
+    {"__py__": "x"},
+    {"__pytype__": "y"},
+    {"__data__": "z"},
+    {"s": {1, 2, 3}},
+    {"fs": frozenset([1, 2])},
+    {"b": b"bytes"},
+    {"t": (1, 2)},
+    {"mix": [1, (2, 3)]},
+]
+
+# non-native AND pre-existingly type-coerced by the serializer (OrderedDict is
+# an isinstance-dict -> plain dict; IntEnum is an isinstance-int -> int). Tier 3
+# only needs to confirm these don't take the fast-path.
+NONNATIVE_COERCED = [
+    OrderedDict(a=1),
+    IntEnum("Color", "RED GREEN")(1),
+    namedtuple("P", "x y")(1, 2),
+]
+
+NONNATIVE = NONNATIVE_ROUNDTRIP + NONNATIVE_COERCED
+
+
+@pytest.mark.parametrize("value", NATIVE)
+def test_native_is_detected(value):
+    assert _is_json_native(value) is True
+
+
+@pytest.mark.parametrize("value", NONNATIVE)
+def test_nonnative_is_rejected(value):
+    assert _is_json_native(value) is False
+
+
+@pytest.mark.parametrize("value", NATIVE)
+def test_fastpath_byte_identical_to_full_path(value):
+    """The whole point: the fast-path must produce exactly what the full path
+    would, so deserialize (which is unchanged) reconstructs the same value."""
+    assert serialize_custom(value) == _full_path(value)
+
+
+@pytest.mark.parametrize("value", NATIVE + NONNATIVE_ROUNDTRIP)
+def test_roundtrip_preserves_value_and_types(value):
+    out = deserialize_custom(serialize_custom(value))
+    assert _nan_aware_eq(out, value), f"{out!r} != {value!r}"
+    assert type(out) is type(value)
+
+
+# --- non-finite floats (the bug the fast-path surfaced) ----------------------
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_non_finite_floats_roundtrip(value):
+    out = deserialize(serialize(value, serializer="hashstash"), serializer="hashstash")
+    if math.isnan(value):
+        assert math.isnan(out)
+    else:
+        assert out == value
+
+
+def test_non_finite_float_fixed_on_full_path_too(tmp_path):
+    """The inf->null corruption (orjson emits null for inf/nan) is fixed at the
+    serializer root, not just in the fast-path — nested non-finite floats that
+    ride the full path (inside a non-native container) also round-trip."""
+    value = {"data": (float("inf"), 1)}  # tuple -> full path
+    assert not _is_json_native(value)
+    out = deserialize(serialize(value, serializer="hashstash"), serializer="hashstash")
+    assert out["data"][0] == float("inf")
+
+
+def test_non_finite_in_stash(tmp_path):
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    stash["k"] = {"score": float("inf"), "vals": [1.0, float("-inf")]}
+    got = stash["k"]
+    assert got["score"] == float("inf")
+    assert got["vals"][1] == float("-inf")
+
+
+# --- keys still use the full (canonical) path --------------------------------
+
+
+def test_keys_not_fastpathed(tmp_path):
+    """Keys must stay on the canonical sort_keys path regardless of the value
+    fast-path (identical bytes across insertion order)."""
+    stash = HashStash(root_dir=str(tmp_path / "c"))
+    assert stash.encode_key({"a": 1, "b": 2}) == stash.encode_key({"b": 2, "a": 1})


### PR DESCRIPTION
**Stacked on #17** (tiers 1+2). Review the top commit; merge #17 first and GitHub retargets this to main.

The structural serializer win from the scoping: skip the recursive rebuild for JSON-shaped values.

## Fast-path
`serialize_custom` detects a purely JSON-native value — recursively None/bool/int/finite-float/str/list/dict-with-str-keys, **exact types only** — and dumps it directly, skipping `_serialize_custom` (the dominant serialization cost).

- **1.9x** on a 20k-record native payload (50ms → 26ms); **~3.2x** combined with tiers 1+2 over the original.
- The native check **early-exits on the first non-native node**, so non-native payloads pay only **~1.2ms (~1.5%)** — measured, not estimated.
- Keys stay on the audited canonical `sort_keys` path (unchanged).

## Correctness (the whole risk of this change)
- **Exact-type checks** (`type(obj) is X`) keep subclasses — OrderedDict, IntEnum, namedtuple, str-subclasses — on the full path, so nothing with custom serialization slips through.
- Dicts with **non-str or reserved-marker keys**, **tuples**, **sets**, and **bytes** are all rejected — a direct dump would read back as the wrong type (tuple→list, int-key→str-key, a `__py__` key misread as an object marker).
- The fast-path output is asserted **byte-identical** to the full path for every native case, so `deserialize` (unchanged) reconstructs the same value.

## Bonus: fixes a real corruption bug the fast-path surfaced
While testing I found that **orjson silently emits null for inf/nan** (it does not raise, contrary to the assumption in the orjson PR) — so non-finite floats were being corrupted to None on **both** paths since that change merged. Non-finite floats now serialize to a tagged `{'__pytype__': 'float'}` form that round-trips through any JSON backend. Fixed at the serializer root, verified on both paths.

## Tests
`tests/test_serializer_fastpath.py` (85 cases): native detection, non-native rejection, byte-identity vs full path, exact-type round-trips across the type matrix, non-finite floats, subclass exclusion, and keys-stay-canonical. Full suite: **982 passed, 121 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
