### PR TITLE
feat(profiler): usable serializer comparison + non-native generator

### DIFF
--- a/hashstash/profilers/engine_profiler.py
+++ b/hashstash/profilers/engine_profiler.py
@@ -291,6 +291,72 @@ class HashStashProfiler:
         return cls.get_profile_data(**{**opts_serializers, **opts})
 
     @classmethod
+    def compare_serializers(
+        cls,
+        serializers=None,
+        sizes=(10_000,),
+        iterations=20,
+        data_types=("dict", "mixed"),
+        engine="memory",
+    ):
+        """Clean per-serializer comparison: for each (serializer, size, data_type)
+        it times serialize + deserialize and records output size, returning a tidy
+        DataFrame with one row per iteration (columns include Serializer, Data
+        Type, Size (B), Serialize/Deserialize Time (s), Serialized Size (B)).
+
+        Unlike get_profile_data() — whose throughput rollup drops the Serializer
+        identity — this reuses the working single-serializer profile() primitive
+        and keeps every dimension, so the result is directly groupable. Include
+        the 'mixed' data type to exercise the serializer's full (non-fast-path)
+        code, since 'dict'/'primitive' produce only JSON-native data.
+
+        Requires pandas.
+        """
+        import tempfile
+
+        import pandas as pd
+
+        serializers = serializers or get_working_serializers()
+        frames = []
+        for serializer in serializers:
+            for size in sizes:
+                for data_type in data_types:
+                    stash = HashStash(
+                        engine=engine,
+                        serializer=serializer,
+                        compress=False,
+                        b64=True,
+                        root_dir=tempfile.mkdtemp(prefix="hs-bench-"),
+                    )
+                    try:
+                        df = cls(stash).profile(
+                            size=size,
+                            iterations=iterations,
+                            num_proc=1,
+                            data_type=data_type,
+                            operations=["Serialize", "Deserialize"],
+                            progress=False,
+                        )
+                    except Exception as e:
+                        # a data-only serializer (msgpack/cbor2) can't encode the
+                        # 'mixed' payload (sets/tuples/bytes) — a real capability
+                        # difference. Record it and keep going.
+                        log.info(
+                            f"{serializer} cannot serialize data_type={data_type!r}: {e}"
+                        )
+                        frames.append(
+                            pd.DataFrame([{
+                                "Serializer": serializer,
+                                "Data Type": data_type,
+                                "Size (B)": size,
+                                "Unsupported": True,
+                            }])
+                        )
+                        continue
+                    frames.append(df)
+        return pd.concat(frames, ignore_index=True)
+
+    @classmethod
     def profile_engines(cls, **opts):
         return cls.get_profile_data(**{**opts_engines, **opts})
 

--- a/hashstash/profilers/profiler.py
+++ b/hashstash/profilers/profiler.py
@@ -59,8 +59,30 @@ def generate_data(
     elif choice == "pandas_df" or choice == "meta_df":
         df = generate_data_dataframe(target_size)
         return MetaDataFrame(df) if choice == "meta_df" else (df.df if isinstance(df, MetaDataFrame) else df)
+    elif choice == "mixed":
+        return generate_mixed(target_size)
     else:
         assert False, f"Invalid data type: {choice}"
+
+
+def generate_mixed(target_size: int) -> Dict[str, Any]:
+    """A payload that deliberately exercises the serializer's FULL path (not the
+    JSON-native fast-path): tuples, sets, bytes, and datetimes alongside a
+    native dict of roughly the target size. Use this to profile realistic
+    non-JSON-shaped values, since generate_dict/generate_primitive only produce
+    JSON-native data (which the fast-path handles)."""
+    # local import: the package's star-import chain rebinds a top-level
+    # `datetime` to the class, shadowing the module — import the class explicitly
+    from datetime import datetime as _dt
+
+    base = generate_dict(target_size)
+    base["_tuple"] = tuple(generate_primitive() for _ in range(8))
+    base["_set"] = set(range(20))
+    base["_frozenset"] = frozenset(("a", "b", "c"))
+    base["_bytes"] = bytes(range(64))
+    base["_datetime"] = _dt(2020, 1, 1, 12, 30, 15)
+    base["_nested"] = [(i, {i, i + 1}, b"x" * 4) for i in range(8)]
+    return base
 
 
 @stashed_dataframe(append_mode=False)

--- a/tests/test_profiler_compare.py
+++ b/tests/test_profiler_compare.py
@@ -1,0 +1,74 @@
+"""compare_serializers() and the non-native 'mixed' generator."""
+import logging
+
+import pytest
+
+pytest.importorskip("pandas")
+
+from hashstash import deserialize, serialize
+from hashstash.profilers.engine_profiler import HashStashProfiler
+from hashstash.profilers.profiler import generate_data, generate_mixed
+
+
+def test_mixed_generator_exercises_full_path():
+    """The 'mixed' payload must contain non-JSON-native types (so the serializer
+    takes its full path, not the fast-path)."""
+    data = generate_mixed(2000)
+    assert isinstance(data["_tuple"], tuple)
+    assert isinstance(data["_set"], set)
+    assert isinstance(data["_bytes"], bytes)
+    # datetime present
+    import datetime
+
+    assert isinstance(data["_datetime"], datetime.datetime)
+
+
+def test_mixed_roundtrips_through_hashstash():
+    data = generate_mixed(2000)
+    out = deserialize(serialize(data, serializer="hashstash"), serializer="hashstash")
+    assert out["_tuple"] == data["_tuple"]
+    assert out["_set"] == data["_set"]
+    assert out["_bytes"] == data["_bytes"]
+    assert out["_datetime"] == data["_datetime"]
+
+
+def test_generate_data_mixed_type():
+    d = generate_data(2000, data_type="mixed")
+    assert isinstance(d, dict)
+    assert "_set" in d
+
+
+def test_compare_serializers_fans_out_and_keeps_identity(caplog):
+    df = HashStashProfiler.compare_serializers(
+        serializers=["hashstash", "pickle", "msgpack"],
+        sizes=(3000,),
+        iterations=4,
+        data_types=("dict", "mixed"),
+    )
+    d = df.df if hasattr(df, "df") else df
+    # every requested serializer is present and identified (the bug: get_profile_data
+    # dropped the Serializer column)
+    assert "Serializer" in d.columns
+    assert set(d["Serializer"].unique()) == {"hashstash", "pickle", "msgpack"}
+    assert "Data Type" in d.columns
+    # timing columns exist for supported combos
+    supported = d[d.get("Unsupported").isna()] if "Unsupported" in d.columns else d
+    assert "Serialize Time (s)" in supported.columns
+    assert supported["Serialize Time (s)"].notna().any()
+
+
+def test_compare_serializers_marks_unsupported():
+    """msgpack cannot encode the 'mixed' payload (sets) — it must be recorded as
+    unsupported, not crash the whole comparison."""
+    df = HashStashProfiler.compare_serializers(
+        serializers=["hashstash", "msgpack"],
+        sizes=(2000,),
+        iterations=3,
+        data_types=("mixed",),
+    )
+    d = df.df if hasattr(df, "df") else df
+    assert "Unsupported" in d.columns
+    unsupported = d[d["Unsupported"] == True]  # noqa: E712
+    assert "msgpack" in set(unsupported["Serializer"])
+    # hashstash handles mixed, so it is NOT unsupported
+    assert "hashstash" not in set(unsupported["Serializer"])


### PR DESCRIPTION
First of the serializer/profiler improvement todos.

## Problem
The in-repo profiler *has* a multi-config runner (`get_profile_data`), but two things made it unusable for serializer work:
1. Its throughput rollup **drops the `Serializer` column**, so results can't be grouped by serializer — the comparison collapses.
2. The data generators only produce **JSON-native** values, so they exercise the serializer's fast-path but never its full path (tuples/sets/datetimes/custom objects).

## Changes
- **`HashStashProfiler.compare_serializers()`** — a clean per-serializer comparison built on the working single-serializer `profile()` primitive. Loops serializers × sizes × data_types, times serialize+deserialize, records output size, and returns a tidy DataFrame keeping every dimension. A serializer that can't encode a payload (e.g. msgpack on sets) is recorded `Unsupported=True` rather than crashing the run.
- **`generate_mixed()` / `data_type="mixed"`** — a payload with tuples, sets, frozensets, bytes, and datetimes, so the serializer's **full** path is profiled, not just the fast-path.

## Example output
```
                      ser_us  deser_us  size_b
Serializer Data Type
cbor2      dict           86        35    6903
           mixed         334        43    7269
hashstash  dict           69       101    8418
           mixed         287       358   10348
msgpack    dict           37        23    6900
pickle     dict           40        24    7237
           mixed          45        30    7714
== unsupported == msgpack / mixed   (can't encode sets)
```
msgpack fastest on JSON data but can't do mixed; pickle fastest overall; hashstash's fast-path (~69µs) vs full-path (~287µs) clearly separated.

This is the measurement baseline for the rest of the serializer perf work (before/after tables, regression tracking). Full suite: **987 passed, 121 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
