### PR TITLE
docs: serializer benchmark script + committed baseline

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,60 @@
+# Serializer benchmarks
+
+Baseline serialize/deserialize throughput and output size for each installed
+serializer, on a JSON-native payload (`dict`) and a full-path payload (`mixed`:
+tuples, sets, bytes, datetimes). Regenerate with:
+
+```bash
+python scripts/bench_serializers.py --sizes 1000 10000 100000 --iterations 25
+```
+
+**These numbers are wall-clock and machine-dependent.** Use them for *relative*
+comparison (serializer vs serializer, fast-path vs full-path) and to catch
+regressions — not as absolute guarantees. `dict` exercises the hashstash
+serializer's JSON-native fast-path; `mixed` forces its full path.
+
+## Baseline (Apple M-series, Python 3.12; ~25 iterations, mean)
+
+| serializer | data type | payload | serialize | deserialize | encoded size |
+|---|---|---:|---:|---:|---:|
+| hashstash | dict | 1,000 B | 18 µs | 28 µs | 1,847 B |
+| hashstash | dict | 10,000 B | 80 µs | 127 µs | 10,478 B |
+| hashstash | dict | 100,000 B | 795 µs | 1,129 µs | 100,666 B |
+| hashstash | mixed | 1,000 B | 194 µs | 230 µs | 3,779 B |
+| hashstash | mixed | 10,000 B | 318 µs | 338 µs | 12,438 B |
+| hashstash | mixed | 100,000 B | 1,668 µs | 1,754 µs | 102,615 B |
+| pickle | dict | 100,000 B | 419 µs | 232 µs | 86,275 B |
+| pickle | mixed | 100,000 B | 430 µs | 235 µs | 86,759 B |
+| msgpack | dict | 100,000 B | 363 µs | 212 µs | 82,446 B |
+| msgpack | mixed | 100,000 B | — | — | *unsupported (sets)* |
+| cbor2 | dict | 100,000 B | 794 µs | 320 µs | 82,468 B |
+| cbor2 | mixed | 100,000 B | 799 µs | 817 µs | 82,840 B |
+| jsonpickle | dict | 100,000 B | 1,995 µs | 3,171 µs | 105,182 B |
+| jsonpickle | mixed | 100,000 B | 2,082 µs | 3,147 µs | 106,299 B |
+
+(A few sizes elided for brevity — run the script for the full sweep.)
+
+## What the numbers say
+
+- **pickle** is the fastest all-rounder and handles every type — but it is not
+  portable across Python versions and is unsafe to load from untrusted sources.
+- **msgpack** is the fastest on JSON-native data and the most compact, but is
+  **data-only**: it cannot encode sets/arbitrary objects (`mixed` is
+  unsupported). Great for trusted, JSON-shaped, cross-language caches.
+- **cbor2** is data-only like msgpack but broader (it encodes the `mixed`
+  payload), compact, and a good `safe=True` pairing.
+- **hashstash** (the default) is competitive with pickle/msgpack on JSON-native
+  data thanks to the fast-path, roughly ~2x their time on `dict` and slower on
+  `mixed` (the full recursive path) — but it is the only serializer here that
+  round-trips *everything* (functions, lambdas, custom objects, numpy/pandas)
+  and produces portable, canonical cache keys.
+- **jsonpickle** is the slowest across the board.
+
+## Choosing
+
+- Trusted local cache, need to cache arbitrary Python objects → **hashstash**
+  (default).
+- Trusted, JSON-shaped, want max speed/compactness → **msgpack**.
+- Shared/untrusted cache → **`safe=True`** with **cbor2** or **msgpack**
+  (data-only serializers can't execute code on load).
+- Never cache across Python versions with **pickle**.

--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,8 @@ LMDB is the fastest engine, followed by the custom "pairtree" implementation.
 
 Pickle is by far the fastest serializer, but it is not transportable between Python versions. HashStash is generally faster than jsonpickle, and can serialize more data types (including lambdas and functions within functions), but it produces larger file sizes.
 
+See [BENCHMARKS.md](./BENCHMARKS.md) for an up-to-date serialize/deserialize speed and size comparison across all serializers (JSON-native vs full-path payloads), regenerable with `python scripts/bench_serializers.py`.
+
 ![Serializers](./figures/fig.comparing_serializers_size_speed.png)
 
 ### Encodings

--- a/scripts/bench_serializers.py
+++ b/scripts/bench_serializers.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Benchmark hashstash serializers and print a Markdown table.
+
+Runs HashStashProfiler.compare_serializers over a size sweep and both a
+JSON-native ('dict') and a full-path ('mixed') payload, then prints mean
+serialize/deserialize time and output size per (serializer, size, data type).
+Serializers that cannot encode a payload (e.g. msgpack on sets) are marked
+"unsupported" rather than dropped.
+
+Usage:
+    python scripts/bench_serializers.py                  # default sweep
+    python scripts/bench_serializers.py --sizes 1000 100000 --iterations 50
+    python scripts/bench_serializers.py --csv results.csv
+
+The numbers are wall-clock and machine-dependent — use them for RELATIVE
+comparison (serializer vs serializer, fast-path vs full-path) and to spot
+regressions, not as absolute guarantees. Regenerate BENCHMARKS.md from this.
+"""
+import argparse
+import logging
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sizes", type=int, nargs="+", default=[1_000, 10_000, 100_000])
+    ap.add_argument("--iterations", type=int, default=30)
+    ap.add_argument(
+        "--serializers", nargs="+", default=None,
+        help="default: all installed serializers",
+    )
+    ap.add_argument("--data-types", nargs="+", default=["dict", "mixed"])
+    ap.add_argument("--csv", default=None, help="also write raw rows to this CSV path")
+    args = ap.parse_args()
+
+    logging.getLogger("hashstash").setLevel(logging.CRITICAL + 1)
+    import warnings
+
+    warnings.filterwarnings("ignore")
+
+    from hashstash.config import get_working_serializers
+    from hashstash.profilers.engine_profiler import HashStashProfiler
+
+    serializers = args.serializers or get_working_serializers()
+
+    df = HashStashProfiler.compare_serializers(
+        serializers=serializers,
+        sizes=tuple(args.sizes),
+        iterations=args.iterations,
+        data_types=tuple(args.data_types),
+    )
+    d = df.df if hasattr(df, "df") else df
+
+    if args.csv:
+        d.to_csv(args.csv, index=False)
+        print(f"# raw rows written to {args.csv}\n")
+
+    unsupported = set()
+    if "Unsupported" in d.columns:
+        for _, r in d[d["Unsupported"] == True].iterrows():  # noqa: E712
+            unsupported.add((r["Serializer"], r["Data Type"], int(r["Size (B)"])))
+        d = d[d["Unsupported"].isna()]
+
+    grp = d.groupby(["Serializer", "Data Type", "Size (B)"])
+    print("| serializer | data type | payload | serialize | deserialize | encoded size |")
+    print("|---|---|---:|---:|---:|---:|")
+    for (serializer, dtype, size), rows in grp:
+        ser_us = rows["Serialize Time (s)"].mean() * 1e6
+        deser_us = rows["Deserialize Time (s)"].mean() * 1e6
+        out_b = rows["Serialized Size (B)"].mean()
+        print(
+            f"| {serializer} | {dtype} | {int(size):,} B "
+            f"| {ser_us:,.0f} µs | {deser_us:,.0f} µs | {out_b:,.0f} B |"
+        )
+    for serializer, dtype, size in sorted(unsupported):
+        print(f"| {serializer} | {dtype} | {size:,} B | — | — | *unsupported* |")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked on #20 (the profiler fix). Task #21.

- **scripts/bench_serializers.py** — runs `compare_serializers` over a size sweep and both JSON-native (`dict`) and full-path (`mixed`) payloads, prints a Markdown table (serialize/deserialize µs + encoded size); unsupported combos marked.
- **BENCHMARKS.md** — committed baseline table + interpretation + a serializer-choosing guide. README links it.

Key takeaways captured: pickle fastest all-rounder (unportable/unsafe); msgpack fastest on JSON but data-only; hashstash competitive on JSON via the fast-path and the only serializer that round-trips arbitrary objects + gives canonical keys; cbor2 a good `safe=True` pairing.

No CI perf job — benchmarks are wall-clock/machine-dependent and noisy; the script is the regeneration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY