### PR TITLE
feat: value-envelope format version (_fv) for migratable format changes

### DIFF
--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -117,6 +117,23 @@ def get_lock(path):
 
 ENVELOPE_MARKER = "__hs_v1__"
 
+# Explicit version stamped into every value envelope (the "_fv" field). Bump this
+# ONLY when an incompatible change is made to how values are wrapped, and add a
+# branch to _migrate_envelope() for the old version. Envelopes written before
+# versioning existed have no "_fv" and read as version 1; the field is plain data,
+# so it costs a couple of bytes and is ignored by older hashstash versions
+# (forward-compatible). Keys are never versioned — they must stay canonical.
+#
+# Scope: this versions the ENVELOPE used by the key-value engines (sqlite, lmdb,
+# redis, mongo, memory, diskcache, shelve). The file-layout engines (pairtree,
+# dataframe, jsonl) store bare values and version through their on-disk layout,
+# so they don't carry "_fv". Serializer-format changes (custom.py __pytype__
+# tags) are handled by tag-dispatch — the deserializer recognizes both old and
+# new tag forms — which is why most format evolution needs no version bump; this
+# field is for changes to the envelope that a structure check alone can't tell
+# apart.
+FORMAT_VERSION = 1
+
 # single-flight key locks are striped across this many lock files per stash:
 # bounded lock-file count, negligible collision odds between distinct keys
 SINGLE_FLIGHT_STRIPES = 256
@@ -223,6 +240,10 @@ def _unwrap_envelope(decoded):
     legacy lists as multiple versions silently corrupted list-valued caches
     (get() returned the last element instead of the list)."""
     if isinstance(decoded, dict) and decoded.get(ENVELOPE_MARKER) is True:
+        # envelopes written before versioning have no "_fv" -> treat as version 1
+        version = decoded.get("_fv", 1)
+        if version != FORMAT_VERSION:
+            decoded = _migrate_envelope(decoded, version)
         values = decoded.get("_values", [])
         timestamps = decoded.get("_written_at", [])
         if len(timestamps) < len(values):
@@ -231,9 +252,29 @@ def _unwrap_envelope(decoded):
     return [decoded], [0.0]
 
 
+def _migrate_envelope(decoded, version):
+    """Bring an envelope written by an older FORMAT_VERSION up to the current one.
+
+    Currently a no-op passthrough (only version 1 exists) — this is the single
+    place to add migration logic when FORMAT_VERSION is bumped, so old caches
+    keep reading instead of silently misinterpreting. A newer-than-known version
+    (data written by a future hashstash) is returned untouched: the envelope
+    fields we read (_values/_written_at) are stable, so forward reads still work.
+    """
+    if version > FORMAT_VERSION:
+        log.debug(
+            f"reading envelope format v{version} with hashstash format "
+            f"v{FORMAT_VERSION}; reading known fields only"
+        )
+        return decoded
+    # if version < FORMAT_VERSION: add per-version migration steps here
+    return decoded
+
+
 def _wrap_envelope(values, timestamps):
     return {
         ENVELOPE_MARKER: True,
+        "_fv": FORMAT_VERSION,
         "_values": list(values),
         "_written_at": list(timestamps),
     }

--- a/tests/test_format_version.py
+++ b/tests/test_format_version.py
@@ -1,0 +1,75 @@
+"""Value-envelope format versioning: new writes are stamped, old (unstamped)
+envelopes read as v1, and future-version data reads its stable fields."""
+import pytest
+
+from hashstash import HashStash
+from hashstash.engines.base import (
+    ENVELOPE_MARKER,
+    FORMAT_VERSION,
+    _migrate_envelope,
+    _unwrap_envelope,
+    _wrap_envelope,
+)
+
+
+def test_new_envelope_is_stamped():
+    env = _wrap_envelope(["v"], [123.0])
+    assert env["_fv"] == FORMAT_VERSION
+
+
+def test_old_unstamped_envelope_reads_as_v1():
+    # an envelope written before versioning existed (no "_fv" field)
+    legacy = {ENVELOPE_MARKER: True, "_values": ["a", "b"], "_written_at": [1.0, 2.0]}
+    values, timestamps = _unwrap_envelope(legacy)
+    assert values == ["a", "b"]
+    assert timestamps == [1.0, 2.0]
+
+
+def test_current_envelope_roundtrips_through_unwrap():
+    env = _wrap_envelope(["x"], [5.0])
+    values, timestamps = _unwrap_envelope(env)
+    assert values == ["x"]
+    assert timestamps == [5.0]
+
+
+def test_future_version_reads_stable_fields():
+    """Data written by a newer hashstash (higher _fv) still reads its known
+    fields rather than being misinterpreted."""
+    future = {
+        ENVELOPE_MARKER: True,
+        "_fv": FORMAT_VERSION + 5,
+        "_values": ["future"],
+        "_written_at": [9.0],
+        "_something_new": 42,  # unknown field, ignored
+    }
+    values, timestamps = _unwrap_envelope(future)
+    assert values == ["future"]
+    assert timestamps == [9.0]
+
+
+def test_migrate_envelope_is_passthrough_for_current():
+    env = _wrap_envelope(["v"], [0.0])
+    assert _migrate_envelope(env, FORMAT_VERSION) == env
+
+
+@pytest.mark.parametrize("engine", ["sqlite", "memory"])
+def test_stored_envelope_carries_version(engine, tmp_path):
+    """Envelope-based engines stamp the version into stored values."""
+    if engine == "sqlite":
+        pytest.importorskip("sqlitedict")
+    stash = HashStash(engine=engine, root_dir=str(tmp_path / engine))
+    stash["k"] = {"a": 1}
+    # read the raw stored envelope back and confirm the version field is present
+    encoded = stash._get(stash.encode_key("k"))
+    decoded = stash.decode_value(encoded)
+    assert decoded.get(ENVELOPE_MARKER) is True
+    assert decoded.get("_fv") == FORMAT_VERSION
+    # and the value still round-trips
+    assert stash["k"] == {"a": 1}
+
+
+def test_value_roundtrip_unaffected(tmp_path):
+    # versioning must not change what get() returns
+    stash = HashStash(engine="memory", root_dir=str(tmp_path / "m"))
+    stash["k"] = {"nested": [1, 2, 3]}
+    assert stash["k"] == {"nested": [1, 2, 3]}


### PR DESCRIPTION
Task #22. Independent of the profiler PRs (#20/#21) — branches off main.

Every value envelope now carries an explicit `FORMAT_VERSION` in a `_fv` field, and `_unwrap_envelope` routes through `_migrate_envelope()` — the single place to add migration logic when the version is bumped, so old caches keep reading instead of being silently misinterpreted after a format change.

- **non-breaking**: old envelopes (no `_fv`) read as v1; the field is plain data, ignored by older hashstash versions (forward-compatible)
- **future-proof**: data written by a newer hashstash (higher `_fv`) still reads its stable fields rather than being misread
- **keys never versioned** — they stay canonical across versions

### Honest scope
This versions the **envelope** used by the key-value engines (sqlite/lmdb/redis/mongo/memory/diskcache/shelve). The file-layout engines (pairtree/dataframe/jsonl) store bare values and version through their on-disk layout, so they don't carry `_fv`. Serializer `__pytype__` tag changes are handled by **tag-dispatch** (the deserializer recognizes both old and new forms), which is why most format evolution needs no version bump — this field is for envelope changes a structure check alone can't disambiguate. I chose this over a universal serializer-level version wrapper because that would change every stored blob (cache-invalidating) for near-zero present benefit.

Full suite: **990 passed, 121 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY