### PR TITLE
feat: safe-by-default on networked engines (engine-aware safe mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ The **`msgpack`** serializer (`serializer="msgpack"`, `pip install
 hashstash[msgpack]`) is data-only by construction — it cannot encode code at
 all — making it a fast, compact, inherently-safe choice for shared caches.
 
+#### Safe by default on shared engines
+
+Because the risk of a hostile value comes from caches other parties can write
+to, **networked engines default to safe mode**: `redis`, `mongo`, and remote
+`fsspec` roots (`s3://`, `gcs://`, `sftp://`, …) open with `safe=True` unless
+you say otherwise. Local file engines you own (`pairtree`, `lmdb`, `sqlite`,
+…) stay code-capable, so caching a lambda locally works out of the box.
+
+```python
+HashStash(engine="redis")                 # safe=True by default
+HashStash(engine="redis", safe=False)     # opt back into code execution (trust the writer)
+HashStash(root_dir="s3://bucket/cache")   # remote fsspec -> safe=True by default
+HashStash()                               # local default engine -> code-capable
+```
+
+If you rely on caching functions/objects to a shared engine, pass `safe=False`
+explicitly to acknowledge that you trust whoever writes to it.
+
 ## Engines & semantics
 
 ### Choosing an engine

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -117,6 +117,21 @@ def get_lock(path):
 
 ENVELOPE_MARKER = "__hs_v1__"
 
+# Engines where the cache may be written by a party you don't control (a shared
+# server, a remote bucket): these default to safe=True reads so a malicious value
+# can't execute code on load. Local file engines you own stay code-capable.
+NETWORKED_ENGINES = frozenset({"redis", "mongo"})
+
+
+def _is_remote_fsspec_uri(root_dir):
+    """True if an fsspec root_dir points at a remote/shared filesystem (s3://,
+    gcs://, sftp://, ...). A plain path or the local/memory protocols are not
+    remote and pose no untrusted-writer risk beyond a local directory."""
+    if not isinstance(root_dir, str) or "://" not in root_dir:
+        return False
+    scheme = root_dir.split("://", 1)[0].lower()
+    return scheme not in ("", "file", "local", "memory")
+
 # single-flight key locks are striped across this many lock files per stash:
 # bounded lock-file count, negligible collision odds between distinct keys
 SINGLE_FLIGHT_STRIPES = 256
@@ -332,9 +347,23 @@ class BaseHashStash(MutableMapping):
             raise ValueError(f"ttl must be positive, got {ttl!r}")
         self.ttl = ttl
         # safe mode: deserialization refuses payloads that would execute code
-        # (see serializers.custom.safe_deserialization); HASHSTASH_SAFE=1 makes
-        # it the default for every stash in the process
-        self.safe = safe if safe is not None else bool(os.environ.get("HASHSTASH_SAFE"))
+        # (see serializers.custom.safe_deserialization). Resolution order:
+        #   explicit safe= arg > HASHSTASH_SAFE=1 (whole process) > engine default.
+        # Networked/shared engines (redis/mongo, remote fsspec) default to safe
+        # reads because their writer may be untrusted; local engines you own stay
+        # code-capable. Only applies to the code-executing hashstash serializer
+        # (data-only serializers are already safe). Override with safe=False.
+        if safe is not None:
+            self.safe = safe
+        elif os.environ.get("HASHSTASH_SAFE"):
+            self.safe = True
+        elif self.serializer == "hashstash" and (
+            self.engine in NETWORKED_ENGINES
+            or (self.engine == "fsspec" and _is_remote_fsspec_uri(root_dir))
+        ):
+            self.safe = True
+        else:
+            self.safe = False
         if self.safe and self.serializer != "hashstash":
             raise ValueError(
                 f"safe=True requires the 'hashstash' serializer; "

--- a/tests/test_engine_safe_default.py
+++ b/tests/test_engine_safe_default.py
@@ -1,0 +1,87 @@
+"""Engine-aware safe default: networked/shared engines (redis, mongo, remote
+fsspec) default to safe=True reads; local engines stay code-capable. Explicit
+safe= and HASHSTASH_SAFE always win."""
+import os
+import tempfile
+
+import pytest
+
+from hashstash import HashStash
+from hashstash.engines.base import _is_remote_fsspec_uri
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("HASHSTASH_SAFE", raising=False)
+
+
+def _safe(**kwargs):
+    return HashStash(**kwargs).safe
+
+
+@pytest.mark.parametrize(
+    "uri,remote",
+    [
+        ("s3://bucket/c", True),
+        ("gcs://b/c", True),
+        ("sftp://host/p", True),
+        ("az://container", True),
+        ("memory://c", False),
+        ("file:///tmp/c", False),
+        ("/plain/local/path", False),
+        ("relative/path", False),
+        (None, False),
+    ],
+)
+def test_is_remote_fsspec_uri(uri, remote):
+    assert _is_remote_fsspec_uri(uri) is remote
+
+
+@pytest.mark.parametrize("engine", ["memory", "sqlite", "pairtree"])
+def test_local_engines_default_code_capable(engine):
+    if engine == "sqlite":
+        pytest.importorskip("sqlitedict")
+    assert _safe(engine=engine, root_dir=tempfile.mkdtemp()) is False
+
+
+@pytest.mark.parametrize("engine", ["redis", "mongo"])
+def test_networked_engines_default_safe(engine):
+    assert _safe(engine=engine) is True
+
+
+def test_remote_fsspec_defaults_safe():
+    assert _safe(engine="fsspec", root_dir="s3://bucket/cache") is True
+
+
+def test_local_fsspec_default_code_capable():
+    assert _safe(engine="fsspec", root_dir="memory://cache") is False
+
+
+def test_explicit_safe_false_overrides_networked_default():
+    assert _safe(engine="redis", safe=False) is False
+
+
+def test_explicit_safe_true_on_local():
+    assert _safe(engine="memory", root_dir=tempfile.mkdtemp(), safe=True) is True
+
+
+def test_data_only_serializer_not_auto_safed():
+    """A data-only serializer is already safe; the auto-default must not set
+    safe=True for it (which would trip the serializer-mismatch guard)."""
+    pytest.importorskip("msgpack")
+    assert _safe(engine="redis", serializer="msgpack") is False
+
+
+def test_hashstash_safe_env_forces_safe(monkeypatch):
+    monkeypatch.setenv("HASHSTASH_SAFE", "1")
+    assert _safe(engine="memory", root_dir=tempfile.mkdtemp()) is True
+
+
+def test_networked_safe_default_still_roundtrips_data(monkeypatch):
+    """The safe default must not break normal data caching (only code payloads)."""
+    # use a local stash but force the networked-style safe default via env
+    monkeypatch.setenv("HASHSTASH_SAFE", "1")
+    stash = HashStash(engine="memory", root_dir=tempfile.mkdtemp())
+    assert stash.safe is True
+    stash["k"] = {"user": "alice", "vals": [1, 2, 3]}
+    assert stash["k"] == {"user": "alice", "vals": [1, 2, 3]}

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -55,7 +55,13 @@ TEST_CLASSES = [
 @pytest.fixture(params=TEST_CLASSES)
 def cache(request, tmp_path):
     cache_type = request.param
-    cache = cache_type(os.path.join(tmp_path, f"{cache_type.__name__.lower()}_cache"))
+    # safe=False so these broad round-trip tests exercise the full code-capable
+    # serializer on every engine. Networked engines (redis/mongo) now default to
+    # safe=True (see test_engine_safe_default.py); this fixture opts back in to
+    # keep testing what it always tested. We trust our own writes here.
+    cache = cache_type(
+        os.path.join(tmp_path, f"{cache_type.__name__.lower()}_cache"), safe=False
+    )
     cache.clear()
     yield cache
 


### PR DESCRIPTION
Task #24 — implements the direction you chose: **engine-aware safe default**.

## What changes
Networked/shared engines now default to `safe=True` reads, because their writer may be untrusted:
- **`redis`, `mongo`** — always
- **remote `fsspec`** roots — `s3://`, `gcs://`, `sftp://`, `az://`, … (but not `memory://`, `file://`, or a plain path)

Local file engines you own (`pairtree`, `lmdb`, `sqlite`, `memory`, …) stay **code-capable**, so caching a lambda locally still works out of the box.

```python
HashStash(engine="redis")                 # safe=True by default
HashStash(engine="redis", safe=False)     # opt back into code (you trust the writer)
HashStash(root_dir="s3://bucket/cache")   # remote fsspec -> safe=True
HashStash()                               # local -> code-capable (unchanged)
```

Resolution order: **explicit `safe=` > `HASHSTASH_SAFE=1` > engine default.** Only applies to the code-executing `hashstash` serializer (data-only serializers are already safe), so it never trips the existing serializer-mismatch guard.

## Why this and not a global flip
This targets the actual threat — a hostile value in a cache others can write to — without the blanket cost of global safe-by-default, which would break the headline "cache any function/object" feature for *everyone*. Local caches you own executing your own code on load is no more dangerous than importing your own module.

## Compatibility
This changes **read** behavior for networked engines: code cached to redis/mongo/remote-fsspec now raises `SafeDeserializationError` on read unless you pass `safe=False`. The error message already tells the user exactly that. Warrants a minor version bump + changelog note.

- `NETWORKED_ENGINES` + `_is_remote_fsspec_uri()` in `base.py`
- README documents the behavior and the `safe=False` opt-out
- `test_engine_safe_default.py` covers the full resolution matrix (21 cases)
- the broad engine-test fixture pins `safe=False` so it keeps exercising the full code-capable serializer on every engine, including redis/mongo under the live test-servers CI

Full suite: **1003 passed, 121 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
