### PR TITLE
fix: harden pmap pool recovery + make CI unable to hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    # backstop so a hung job fails in minutes instead of GitHub's 6h default
+    # (a flaky macOS spawn-multiprocessing deadlock once ran 27+ min before)
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -38,8 +41,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+    # --timeout: a hung TEST fails with a traceback (pointing at the culprit)
+    # after 180s instead of hanging the whole job. thread method works when the
+    # main thread is blocked joining a multiprocessing worker.
     - name: Run tests with coverage
-      run: pytest --cov=hashstash --cov-report=xml
+      run: pytest --cov=hashstash --cov-report=xml --timeout=180 --timeout-method=thread
     - name: Upload results to Codecov
       if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v4
@@ -50,6 +56,7 @@ jobs:
   # server-backed engines (redis, mongo) run against real services on linux
   test-servers:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       redis:
         image: redis
@@ -70,4 +77,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
     - name: Run engine tests against live servers
-      run: pytest tests/test_engines.py tests/test_regressions.py tests/test_written_at.py
+      run: pytest tests/test_engines.py tests/test_regressions.py tests/test_written_at.py --timeout=180 --timeout-method=thread

--- a/hashstash/utils/pmap.py
+++ b/hashstash/utils/pmap.py
@@ -39,7 +39,18 @@ def get_global_executor(num_proc):
     key = (os.getpid(), num_proc)
     with executor_lock:
         executor = executors.get(key)
-        if executor is None or getattr(executor, "_broken", False):
+        # A worker raising a NORMAL exception does not set _broken, but the
+        # spawn pool can still be left in a state where a LATER pmap deadlocks
+        # (observed as a flaky macOS-CI hang in test_pmap_pool_usable_after_
+        # worker_exception). So we also replace a pool we tainted after a worker
+        # error. Replacement happens here (between pmaps), never mid-pmap, so the
+        # tainting pmap's remaining items still complete on the old pool.
+        if (
+            executor is None
+            or getattr(executor, "_broken", False)
+            or getattr(executor, "_hs_tainted", False)
+        ):
+            old = executor
             # explicit spawn context: on Linux <= 3.13 the default is fork, and
             # forking a worker while another thread (future callbacks, logging)
             # holds a lock deadlocks the child — pmap is inherently multi-threaded.
@@ -48,7 +59,23 @@ def get_global_executor(num_proc):
             executor = executors[key] = ProcessPoolExecutor(
                 max_workers=num_proc, mp_context=mp.get_context("spawn")
             )
+            if old is not None:
+                # don't wait: any still-in-flight futures on the old pool finish,
+                # then its workers exit; we just stop handing it out.
+                old.shutdown(wait=False)
         return executor
+
+
+def taint_global_executor(num_proc):
+    """Mark the cached pool for (pid, num_proc) so the NEXT get_global_executor
+    replaces it. Called when a worker future raises — a normal task exception
+    leaves _broken unset, but the pool may still deadlock a later pmap on spawn."""
+    global executors
+    key = (os.getpid(), num_proc)
+    with executor_lock:
+        executor = executors.get(key)
+        if executor is not None:
+            executor._hs_tainted = True
 
 def shutdown_global_executors():
     global executors
@@ -543,6 +570,11 @@ class StashMapRun:
                     # raising here would be swallowed by add_done_callback:
                     # remember the failure and re-raise when .result is read
                     self._error = e
+                    # taint the shared pool so the next pmap gets a fresh one —
+                    # a worker exception can otherwise leave the spawn pool in a
+                    # state that deadlocks a later call
+                    if self._pmap_instance.num_proc > 1:
+                        taint_global_executor(self._pmap_instance.num_proc)
             else:
                 self._result = future_or_result
         if self._pmap_instance.progress_bar:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
   "scikit-misc",
 
   # dev tools
-  "pytest", "pytest-cov", "setuptools-scm", "ipython",
+  "pytest", "pytest-cov", "pytest-timeout", "setuptools-scm", "ipython",
 ]
 all = [
   # engines

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -56,6 +56,21 @@ def test_pmap_pool_usable_after_worker_exception():
         list(pmap(failing_function, objects=[2], num_proc=2))
     assert list(pmap(square, objects=[3], num_proc=2)) == [9]
 
+
+def test_worker_exception_replaces_pool():
+    """A worker exception taints the shared spawn pool so the NEXT pmap gets a
+    fresh executor — a reused poisoned pool can deadlock a later call (flaky
+    macOS-CI hang). Verify the pool object is actually replaced."""
+    from hashstash.utils.pmap import get_global_executor
+
+    before = get_global_executor(2)
+    with pytest.raises(ValueError):
+        list(pmap(failing_function, objects=[2], num_proc=2))
+    assert getattr(before, "_hs_tainted", False) is True
+    assert list(pmap(square, objects=[3], num_proc=2)) == [9]
+    after = get_global_executor(2)
+    assert after is not before  # fresh pool handed out
+
 @pytest.fixture
 def mock_log_prefix_str():
     with patch('hashstash.utils.logs.log_prefix_str', return_value='Test') as mock:


### PR DESCRIPTION
The macOS CI lane intermittently **hung for 27+ minutes** (normal ~1m40s) in `test_pmap_pool_usable_after_worker_exception`, blocking #23/#24. I traced it to the exact test via the cancelled run's log (last line: `test_pmap_exception_propagates PASSED [63%]`, next test never printed).

## Root cause
A worker raising a **normal exception** (e.g. `ValueError`) does **not** set `ProcessPoolExecutor._broken`, so pmap's cached **spawn** pool was reused by the next pmap — and a reused spawn pool can deadlock. Flaky: passed 80+ local runs and on macOS at 21:06, hung at 23:01. It reproduced locally exactly **once**, which was enough to confirm the mechanism and that `pytest-timeout` catches it.

## Fixes
1. **pmap pool recovery** — a worker exception now *taints* the shared pool (`taint_global_executor`); `get_global_executor` hands out a **fresh** pool on the next call and shuts the tainted one down `wait=False`. Replacement happens **between** pmaps, never mid-pmap, so the failing pmap's remaining items still finish on the old pool. (`test_worker_exception_replaces_pool` locks this in.)
2. **CI can no longer hang** — `pytest-timeout` (`--timeout=180 --timeout-method=thread`) turns a hung test into a fast failure with a traceback naming the culprit; `timeout-minutes: 20` is a job backstop vs GitHub's 6-hour default. `pytest-timeout` added to the dev extra.

## Verification
50 isolated `test_pmap.py` runs + 30 full-suite runs + full suite all green locally (996 passed) with the taint fix. This PR's own **macOS lane** is the real test of the fix. Even if a rare flake survives, it now fails in <3 min with a stack trace instead of hanging for hours.

Once this lands, I'll rebase #23/#24 onto it so their macOS lanes get the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
