### PR TITLE
feat: comprehensive numpy/pandas round-trips + hypothesis property test

### DIFF
--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -2,6 +2,7 @@
 # circular, and whether a name has landed in the package namespace yet
 # depends on import order (spawn workers + editable installs order imports
 # differently). Never rely on the star-chain for stdlib names.
+import enum
 import importlib
 import inspect
 import os
@@ -219,13 +220,28 @@ def _serialize_custom(obj: Any, data:Any=None) -> Any:
             '__data__': _serialize_custom(data)
         }
 
+    # Enum BEFORE the primitive check: IntEnum/IntFlag are int subclasses, so the
+    # primitive branch would coerce them to a bare int and lose the type; a plain
+    # Enum otherwise fell to the instance path and recursed forever (serializing
+    # the class re-serializes its members). Stored as class-address + member name.
+    if isinstance(obj, enum.Enum):
+        return {
+            '__py__': get_obj_addr(type(obj)),
+            '__pytype__': 'enum',
+            '__data__': obj.name,
+        }
 
     if isinstance(obj, float):
         # non-finite floats round-trip through a tagged form: orjson emits null
         # for inf/nan (silent data loss) and stdlib json emits non-standard
-        # Infinity/NaN. The tag survives any JSON backend.
-        if obj != obj or obj == float("inf") or obj == float("-inf"):
-            return {'__pytype__': 'float', '__val__': repr(obj)}
+        # Infinity/NaN. Store a CANONICAL token, not repr(obj): a float subclass
+        # like np.float64 reprs as 'np.float64(inf)', which float() can't parse.
+        if obj != obj:
+            return {'__pytype__': 'float', '__val__': 'nan'}
+        if obj == float("inf"):
+            return {'__pytype__': 'float', '__val__': 'inf'}
+        if obj == float("-inf"):
+            return {'__pytype__': 'float', '__val__': '-inf'}
         return obj
 
     if isinstance(obj, (str, int, bool)):
@@ -355,6 +371,13 @@ def _deserialize_custom(data: Any) -> Any:
         if pytype == 'float':
             return float(data['__val__'])
 
+        if pytype == 'enum':
+            # reconstructing an enum member requires importing its class, which
+            # (like any import reference) can execute module-level code
+            if _safe_mode_active():
+                _refuse_unsafe(f"an enum ({addr!r})")
+            return flexible_import(addr)[data['__data__']]
+
         if pytype == 'instance':
             if _safe_mode_active():
                 _refuse_unsafe(f"an instance of {addr!r}")
@@ -479,53 +502,65 @@ def pandas_installed():
 
 
 class PandasDataFrameSerializer(CustomSerializer):
+    """Column-wise: each column is serialized as its own Series (preserving that
+    column's exact dtype — nullable/categorical/tz/object all survive), alongside
+    the row index and the columns Index. This avoids df.values, which collapses
+    every column to one common dtype and can't be recovered faithfully."""
+
     @staticmethod
     def serialize(obj):
         assert pandas_installed(), "Pandas is required for this serializer."
-        if pandas_extension_activated():
-            # log.debug("serializing MetaDataFrame")
-            mdf = MetaDataFrame(obj)
-            return {
-                '__py__': get_obj_addr(obj),
-                '__data__': MetaDataFrameSerializer.serialize(mdf)
-            }
-        else:
-            df, index = reset_index_misc(obj, _index=True)
-            return {
-                '__py__': get_obj_addr(obj),
-                '__data__': {
-                    'values': NumpySerializer.serialize(df.values),
-                    'columns': NumpySerializer.serialize(df.columns.values),
-                    'index_columns': _serialize_custom(index),
-                    'dtypes': _serialize_custom({k:str(v) for k,v in df.dtypes.to_dict().items()})
-                }
-            }
+        return {
+            '__py__': get_obj_addr(obj),
+            '__pytype__': 'pd_dataframe',
+            '__data__': {
+                'columns': PandasIndexSerializer.serialize(obj.columns),
+                'index': PandasIndexSerializer.serialize(obj.index),
+                # positional column-Series (handles duplicate/ non-str column labels)
+                'series': [
+                    PandasSeriesSerializer.serialize(obj.iloc[:, i])
+                    for i in range(obj.shape[1])
+                ],
+            },
+        }
 
     @staticmethod
     def deserialize(data):
         assert pandas_installed(), "Pandas is required for this serializer."
+        import pandas as pd
 
-        if pandas_extension_activated():
-            # log.info("deserializing MetaDataFrame")
-            mdf = MetaDataFrameSerializer.deserialize(data['__data__'])
-            # log.debug(f"deserialized MetaDataFrame with shape {mdf.data.shape}")
-            return mdf.data
+        d = data['__data__']
+        columns = PandasIndexSerializer.deserialize(d['columns'])
+        index = PandasIndexSerializer.deserialize(d['index'])
+        cols = [PandasSeriesSerializer.deserialize(s) for s in d['series']]
+        if cols:
+            df = pd.concat(cols, axis=1, keys=range(len(cols)))
+            df.columns = columns          # restore real labels (incl. duplicates / dtype)
         else:
-            import pandas as pd
-            values = NumpySerializer.deserialize(data['__data__']['values'])
-            columns = NumpySerializer.deserialize(data['__data__']['columns'])
-            index_columns = _deserialize_custom(data['__data__'].get('index_columns'))
-            dtypes = _deserialize_custom(data['__data__']['dtypes'])
-            
-            df = pd.DataFrame(values, columns=columns)
-            for col, dtype in dtypes.items():
-                df[col] = df[col].astype(dtype)
-            
-            if index_columns:
-                df = df.set_index(index_columns)
-            if index_columns == ['_index']:
-                df = df.rename_axis(None)
-            return df
+            df = pd.DataFrame(index=index, columns=columns)
+        df.index = index
+        return df
+
+def _dtype_to_data(dtype):
+    # structured dtypes have field names; str(dtype) of a structured dtype is not
+    # reparseable by np.dtype, so store the descr (a list of field tuples). Plain
+    # dtypes round-trip fine as their string.
+    return dtype.descr if dtype.names else str(dtype)
+
+
+def _data_to_dtype(spec):
+    import numpy as np
+    if isinstance(spec, list):
+        # JSON turned each field tuple (and any subarray shape) into a list
+        fields = []
+        for f in spec:
+            if len(f) >= 3 and isinstance(f[2], list):
+                fields.append((f[0], f[1], tuple(f[2])))
+            else:
+                fields.append(tuple(f))
+        return np.dtype(fields)
+    return np.dtype(spec)
+
 
 class NumpySerializer(CustomSerializer):
     @staticmethod
@@ -533,7 +568,7 @@ class NumpySerializer(CustomSerializer):
         outd = {
             '__py__': get_obj_addr(obj),
             '__data__': {
-                'dtype': str(obj.dtype),
+                'dtype': _dtype_to_data(obj.dtype),
                 'shape': obj.shape
             }
         }
@@ -549,8 +584,8 @@ class NumpySerializer(CustomSerializer):
             import numpy as np
         except ImportError:
             raise ImportError("NumPy is required for this deserializer.")
-        dtype = data['__data__']['dtype']
-        shape = data['__data__']['shape']
+        dtype = _data_to_dtype(data['__data__']['dtype'])
+        shape = tuple(data['__data__']['shape'])
         if 'bytes' in data['__data__']:
             arr_bytes = decode(data['__data__']['bytes'], compress=False, b64=True)
             return np.frombuffer(arr_bytes, dtype=dtype).reshape(shape)
@@ -648,15 +683,105 @@ class PandasNaTSerializer(CustomSerializer):
             raise ImportError("pandas is required for this deserializer.")
         return pd.NaT
 
-class PandasSeriesSerializer(CustomSerializer):
+
+class NumpyDatetime64Serializer(CustomSerializer):
+    """numpy.datetime64 / numpy.timedelta64 — like the other numpy scalars they
+    fell to the generic reducer and failed to reconstruct. Stored as the raw
+    int64 view plus the dtype (which carries the time unit); rebuilt by viewing
+    the int back as that dtype, preserving unit and value (incl. NaT)."""
+
     @staticmethod
     def serialize(obj):
         return {
             '__py__': get_obj_addr(obj),
+            '__pytype__': 'np_datetime64',
+            '__data__': {'dtype': str(obj.dtype), 'value': int(obj.view('int64'))},
+        }
+
+    @staticmethod
+    def deserialize(data):
+        try:
+            import numpy as np
+        except ImportError:
+            raise ImportError("NumPy is required for this deserializer.")
+        d = data['__data__']
+        return np.int64(d['value']).view(d['dtype'])
+
+
+class PandasPeriodSerializer(CustomSerializer):
+    """pandas.Period — took the generic instance path and silently round-tripped
+    to NaT. Stored as its ordinal + frequency string and rebuilt exactly."""
+
+    @staticmethod
+    def serialize(obj):
+        return {
+            '__py__': get_obj_addr(obj),
+            '__pytype__': 'pd_period',
+            '__data__': {'ordinal': obj.ordinal, 'freq': obj.freqstr},
+        }
+
+    @staticmethod
+    def deserialize(data):
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError("pandas is required for this deserializer.")
+        d = data['__data__']
+        return pd.Period(ordinal=d['ordinal'], freq=d['freq'])
+
+
+class ZoneInfoSerializer(CustomSerializer):
+    """zoneinfo.ZoneInfo — the reducer couldn't reconstruct it. Stored as its IANA
+    key and rebuilt with ZoneInfo(key)."""
+
+    @staticmethod
+    def serialize(obj):
+        return {
+            '__py__': get_obj_addr(obj),
+            '__pytype__': 'zoneinfo',
+            '__data__': {'key': obj.key},
+        }
+
+    @staticmethod
+    def deserialize(data):
+        from zoneinfo import ZoneInfo
+        return ZoneInfo(data['__data__']['key'])
+
+
+class PandasSeriesSerializer(CustomSerializer):
+    """Preserves the Series' exact dtype (incl. nullable Int64/boolean/string,
+    categorical, datetime-with-tz), its name, and its index. numpy-backed
+    numeric data takes the fast bytes path; ExtensionArray-backed data is stored
+    as elements + dtype (categoricals keep their category order via the
+    Categorical serializer)."""
+
+    @staticmethod
+    def serialize(obj):
+        import numpy as np
+        import pandas as pd
+        values = obj.values
+        if isinstance(values, pd.Categorical):
+            vdata = {'kind': 'categorical', 'data': PandasCategoricalSerializer.serialize(values)}
+        elif isinstance(obj.dtype, np.dtype) and obj.dtype.kind != 'O':
+            # a genuine numpy dtype (int/float/bool/naive-datetime): fast bytes path.
+            # Checked on obj.dtype, NOT values.dtype: a tz-aware series is an
+            # ExtensionDtype whose .values is a NAIVE numpy array — routing it here
+            # would silently drop the timezone.
+            vdata = {'kind': 'numpy', 'data': NumpySerializer.serialize(values)}
+        else:
+            # object ndarray, or an ExtensionArray (nullable Int64/boolean/string,
+            # tz-aware datetime, period, interval): a plain element list round-trips
+            # every element; the exact dtype is re-applied on load.
+            vdata = {'kind': 'list', 'data': _serialize_custom(obj.tolist())}
+        return {
+            '__py__': get_obj_addr(obj),
+            '__pytype__': 'pd_series',
             '__data__': {
-                'values': NumpySerializer.serialize(obj.values),
-                'index': NumpySerializer.serialize(obj.index.values)
-            }
+                'values': vdata,
+                'dtype': str(obj.dtype),
+                'name': _serialize_custom(obj.name),
+                'index': PandasIndexSerializer.serialize(obj.index),
+            },
         }
 
     @staticmethod
@@ -665,9 +790,97 @@ class PandasSeriesSerializer(CustomSerializer):
             import pandas as pd
         except ImportError:
             raise ImportError("Pandas is required for this deserializer.")
-        return pd.Series(
-            NumpySerializer.deserialize(data['__data__']['values']),
-            index=NumpySerializer.deserialize(data['__data__']['index'])
+        d = data['__data__']
+        vkind = d['values']['kind']
+        if vkind == 'categorical':
+            values = PandasCategoricalSerializer.deserialize(d['values']['data'])
+        elif vkind == 'numpy':
+            values = NumpySerializer.deserialize(d['values']['data'])
+        else:
+            values = _deserialize_custom(d['values']['data'])
+        index = PandasIndexSerializer.deserialize(d['index'])
+        s = pd.Series(values, index=index, name=_deserialize_custom(d['name']))
+        # re-apply the exact dtype for the list path (nullable Int64/boolean/string)
+        if vkind == 'list' and str(s.dtype) != d['dtype']:
+            s = s.astype(d['dtype'])
+        return s
+
+
+class PandasIndexSerializer(CustomSerializer):
+    """All pandas Index flavours: MultiIndex (from tuples), RangeIndex (start/
+    stop/step), and everything else via its element list + dtype (which covers
+    Int/Float/Datetime/Period/Interval/Categorical indexes)."""
+
+    @staticmethod
+    def serialize(obj):
+        import pandas as pd
+        if isinstance(obj, pd.MultiIndex):
+            payload = {
+                'kind': 'multi',
+                'tuples': _serialize_custom([tuple(t) for t in obj]),
+                'names': _serialize_custom(list(obj.names)),
+            }
+        elif isinstance(obj, pd.RangeIndex):
+            payload = {
+                'kind': 'range',
+                'start': int(obj.start), 'stop': int(obj.stop), 'step': int(obj.step),
+                'name': _serialize_custom(obj.name),
+            }
+        else:
+            payload = {
+                'kind': 'index',
+                'values': _serialize_custom(obj.tolist()),
+                'dtype': str(obj.dtype),
+                'name': _serialize_custom(obj.name),
+            }
+        return {'__py__': get_obj_addr(obj), '__pytype__': 'pd_index', '__data__': payload}
+
+    @staticmethod
+    def deserialize(data):
+        import pandas as pd
+        d = data['__data__']
+        kind = d['kind']
+        if kind == 'multi':
+            return pd.MultiIndex.from_tuples(
+                _deserialize_custom(d['tuples']), names=_deserialize_custom(d['names'])
+            )
+        if kind == 'range':
+            return pd.RangeIndex(
+                d['start'], d['stop'], d['step'], name=_deserialize_custom(d['name'])
+            )
+        return pd.Index(
+            _deserialize_custom(d['values']), dtype=d['dtype'],
+            name=_deserialize_custom(d['name']),
+        )
+
+
+class PandasCategoricalSerializer(CustomSerializer):
+    """pandas.Categorical — stored as its categories + integer codes + ordered
+    flag, preserving category identity and order exactly (unlike inferring
+    categories from the values, which would re-sort them)."""
+
+    @staticmethod
+    def serialize(obj):
+        return {
+            '__py__': get_obj_addr(obj),
+            '__pytype__': 'pd_categorical',
+            '__data__': {
+                'categories': _serialize_custom(obj.categories.tolist()),
+                'codes': obj.codes.tolist(),
+                'ordered': bool(obj.ordered),
+            },
+        }
+
+    @staticmethod
+    def deserialize(data):
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError("Pandas is required for this deserializer.")
+        d = data['__data__']
+        return pd.Categorical.from_codes(
+            d['codes'], categories=_deserialize_custom(d['categories']),
+            ordered=d['ordered'],
         )
 
 class ReducerSerializer(CustomSerializer):
@@ -1076,6 +1289,38 @@ for _addr in (
 ):
     CUSTOM_SERIALIZERS[_addr] = PandasNaTSerializer.serialize
     CUSTOM_DESERIALIZERS[_addr] = PandasNaTSerializer.deserialize
+for _addr in (
+    'pandas._libs.tslibs.period.Period',
+    'pandas.Period',  # pandas 3.x top-level path
+):
+    CUSTOM_SERIALIZERS[_addr] = PandasPeriodSerializer.serialize
+    CUSTOM_DESERIALIZERS[_addr] = PandasPeriodSerializer.deserialize
+CUSTOM_SERIALIZERS['zoneinfo.ZoneInfo'] = ZoneInfoSerializer.serialize
+CUSTOM_DESERIALIZERS['zoneinfo.ZoneInfo'] = ZoneInfoSerializer.deserialize
+for _addr in ('numpy.datetime64', 'numpy.timedelta64'):
+    CUSTOM_SERIALIZERS[_addr] = NumpyDatetime64Serializer.serialize
+    CUSTOM_DESERIALIZERS[_addr] = NumpyDatetime64Serializer.deserialize
+# numpy string/bytes scalars (str_ is a str subclass caught by the primitive
+# branch, so its registration is only reachable for bytes_, but both are listed)
+for _addr in ('numpy.bytes_', 'numpy.str_'):
+    CUSTOM_SERIALIZERS[_addr] = NumpyScalarSerializer.serialize
+    CUSTOM_DESERIALIZERS[_addr] = NumpyScalarSerializer.deserialize
+# pandas Index family -> one serializer (internal + pandas-3.x top-level paths)
+for _addr in (
+    'pandas.core.indexes.base.Index', 'pandas.Index',
+    'pandas.core.indexes.range.RangeIndex', 'pandas.RangeIndex',
+    'pandas.core.indexes.datetimes.DatetimeIndex', 'pandas.DatetimeIndex',
+    'pandas.core.indexes.timedeltas.TimedeltaIndex', 'pandas.TimedeltaIndex',
+    'pandas.core.indexes.period.PeriodIndex', 'pandas.PeriodIndex',
+    'pandas.core.indexes.interval.IntervalIndex', 'pandas.IntervalIndex',
+    'pandas.core.indexes.category.CategoricalIndex', 'pandas.CategoricalIndex',
+    'pandas.core.indexes.multi.MultiIndex', 'pandas.MultiIndex',
+):
+    CUSTOM_SERIALIZERS[_addr] = PandasIndexSerializer.serialize
+    CUSTOM_DESERIALIZERS[_addr] = PandasIndexSerializer.deserialize
+for _addr in ('pandas.core.arrays.categorical.Categorical', 'pandas.Categorical'):
+    CUSTOM_SERIALIZERS[_addr] = PandasCategoricalSerializer.serialize
+    CUSTOM_DESERIALIZERS[_addr] = PandasCategoricalSerializer.deserialize
 
 
 # numpy scalar types registered by ADDRESS STRING so that `import hashstash`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
   "scikit-misc",
 
   # dev tools
-  "pytest", "pytest-cov", "pytest-timeout", "setuptools-scm", "ipython",
+  "pytest", "pytest-cov", "pytest-timeout", "hypothesis", "setuptools-scm", "ipython",
 ]
 all = [
   # engines

--- a/tests/test_roundtrip_property.py
+++ b/tests/test_roundtrip_property.py
@@ -1,0 +1,272 @@
+"""Property-based round-trip law for the hashstash serializer:
+
+    deserialize(serialize(x)) == x   for all x in a broad type space.
+
+Unlike the fixed example matrix (test_type_matrix.py), this GENERATES values
+across the stdlib + numpy + pandas type zoo, so it keeps probing combinations
+nobody enumerated. Every serializer gap in this codebase's history (numpy
+scalars, pandas Timestamp/NaT/Period, enums, nullable/categorical/tz columns)
+would have been caught here.
+"""
+import datetime as dt
+import decimal
+import fractions
+import zoneinfo
+from collections import Counter, OrderedDict, deque
+from enum import Enum, IntEnum
+
+import pytest
+from hypothesis import given, settings, strategies as st, HealthCheck
+
+from hashstash import deserialize, serialize
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+from hypothesis.extra import numpy as hnp  # noqa: E402
+from hypothesis.extra import pandas as hpd  # noqa: E402
+
+SETTINGS = settings(max_examples=60, deadline=None, suppress_health_check=list(HealthCheck))
+
+
+def rt(v):
+    return deserialize(serialize(v, serializer="hashstash"), serializer="hashstash")
+
+
+def eq(a, b):
+    """nan/NaT-aware structural equality across the type zoo."""
+    if isinstance(a, np.ndarray):
+        if not isinstance(b, np.ndarray) or a.dtype != b.dtype or a.shape != b.shape:
+            return False
+        if a.dtype.kind in "fc":
+            return np.array_equal(a, b, equal_nan=True)
+        if a.dtype.kind in "mM":  # datetime64/timedelta64: NaT != NaT
+            return bool((np.isnat(a) == np.isnat(b)).all() and (a[~np.isnat(a)] == b[~np.isnat(b)]).all())
+        if a.dtype.kind == "V":  # structured/void: nan fields defeat array_equal
+            return a.tobytes() == b.tobytes()
+        return np.array_equal(a, b)
+    if isinstance(a, pd.Series):
+        try: pd.testing.assert_series_equal(a, b); return True
+        except Exception: return False
+    if isinstance(a, pd.DataFrame):
+        try: pd.testing.assert_frame_equal(a, b); return True
+        except Exception: return False
+    if isinstance(a, pd.Index):
+        try: pd.testing.assert_index_equal(a, b); return True
+        except Exception: return False
+    if isinstance(a, pd.Categorical):
+        return isinstance(b, pd.Categorical) and a.equals(b)
+    if isinstance(a, float) and isinstance(b, float):
+        return a == b or (a != a and b != b)
+    if isinstance(a, np.generic):
+        try:
+            if np.isnat(a):
+                return type(a) is type(b) and bool(np.isnat(b))
+        except TypeError:
+            pass
+    # containers: recurse so nan/NaT nested inside still compares equal
+    if isinstance(a, (list, tuple, deque)):
+        return type(a) is type(b) and len(a) == len(b) and all(eq(x, y) for x, y in zip(a, b))
+    if isinstance(a, dict):
+        return type(a) is type(b) and list(a.keys()) == list(b.keys()) and all(eq(a[k], b[k]) for k in a)
+    if isinstance(a, (set, frozenset)):
+        return type(a) is type(b) and a == b
+    try:
+        if pd.isna(a) and pd.isna(b):
+            return True
+    except (TypeError, ValueError):
+        pass
+    return type(a) is type(b) and bool(a == b)
+
+
+# --------------------------------------------------------------------------
+# stdlib / builtin recursive space
+# --------------------------------------------------------------------------
+
+class _Color(Enum):
+    RED = 1
+    GREEN = "green"
+
+
+class _Size(IntEnum):
+    S = 1
+    L = 3
+
+
+_LEAVES = st.one_of(
+    st.none(), st.booleans(), st.integers(),
+    st.floats(allow_nan=True, allow_infinity=True),
+    st.text(), st.binary(),
+    st.decimals(allow_nan=False), st.fractions(), st.complex_numbers(allow_nan=False),
+    st.datetimes(), st.dates(), st.times(), st.timedeltas(), st.uuids(),
+    st.sampled_from(list(_Color)), st.sampled_from(list(_Size)),
+    st.builds(zoneinfo.ZoneInfo, st.sampled_from(["UTC", "America/New_York"])),
+)
+
+
+@st.composite
+def _hashable(draw):
+    return draw(st.one_of(st.none(), st.booleans(), st.integers(), st.text(), st.binary(),
+                          st.tuples(st.integers(), st.text())))
+
+
+_NESTED = st.recursive(
+    _LEAVES,
+    lambda children: st.one_of(
+        st.lists(children),
+        st.tuples(children, children),
+        st.dictionaries(_hashable(), children, max_size=5),
+        st.sets(_hashable()),
+        st.builds(OrderedDict, st.dictionaries(st.text(), children, max_size=4)),
+        st.builds(deque, st.lists(children, max_size=4)),
+    ),
+    max_leaves=25,
+)
+
+
+@SETTINGS
+@given(_NESTED)
+def test_stdlib_nested_roundtrip(v):
+    assert eq(rt(v), v)
+
+
+# --------------------------------------------------------------------------
+# numpy: arrays (all dtypes, 0-3d), scalars, structured
+# --------------------------------------------------------------------------
+
+_NP_DTYPES = st.one_of(
+    hnp.integer_dtypes(), hnp.unsigned_integer_dtypes(),
+    hnp.floating_dtypes(), hnp.complex_number_dtypes(), hnp.boolean_dtypes(),
+    hnp.datetime64_dtypes(), hnp.timedelta64_dtypes(),
+    hnp.unicode_string_dtypes(), hnp.byte_string_dtypes(),
+)
+
+
+@SETTINGS
+@given(hnp.arrays(dtype=_NP_DTYPES, shape=hnp.array_shapes(min_dims=0, max_dims=3, max_side=4)))
+def test_numpy_array_roundtrip(a):
+    assert eq(rt(a), a)
+
+
+@SETTINGS
+@given(hnp.arrays(dtype=np.dtype([("x", "i4"), ("y", "f8"), ("z", "?")]),
+                  shape=hnp.array_shapes(min_dims=1, max_dims=1, max_side=5)))
+def test_numpy_structured_array_roundtrip(a):
+    assert eq(rt(a), a)
+
+
+@SETTINGS
+@given(hnp.arrays(dtype=st.one_of(hnp.integer_dtypes(), hnp.floating_dtypes(),
+                                  hnp.datetime64_dtypes(), hnp.boolean_dtypes()),
+                  shape=()).map(lambda z: z[()]))
+def test_numpy_scalar_roundtrip(s):
+    out = rt(s)
+    same = bool(out == s)
+    if isinstance(s, np.floating) and np.isnan(s):
+        same = bool(np.isnan(out))
+    try:
+        if np.isnat(s):
+            same = bool(np.isnat(out))
+    except TypeError:
+        pass
+    assert same
+    # np.float64 (a float subclass) and np.str_ (a str subclass) intentionally
+    # coerce to the Python type: value-preserving, and preserving the numpy type
+    # would cost a check in the serialization hot path. All other scalar types
+    # keep their exact numpy type.
+    if not isinstance(s, (np.float64, np.str_)):
+        assert type(out) is type(s)
+
+
+# --------------------------------------------------------------------------
+# pandas: scalars, Series (incl nullable/categorical), Index family, DataFrame
+# --------------------------------------------------------------------------
+
+@SETTINGS
+@given(st.one_of(
+    st.integers(0, 2**31).map(lambda n: pd.Timestamp(n, unit="s")),
+    st.integers(0, 2**31).map(lambda n: pd.Timestamp(n, unit="s", tz="UTC")),
+    st.integers(-(2**31), 2**31).map(lambda n: pd.Timedelta(n, unit="s")),
+    st.integers(1980, 2050).map(lambda y: pd.Period(year=y, freq="Y")),
+    st.integers(-100, 100).map(lambda a: pd.Interval(a, a + 5)),
+    st.just(pd.NaT),
+))
+def test_pandas_scalar_roundtrip(v):
+    assert eq(rt(v), v)
+
+
+@SETTINGS
+@given(st.one_of(
+    hpd.series(dtype=int), hpd.series(dtype=float),
+    hpd.series(dtype="datetime64[ns]"), hpd.series(dtype=bool),
+    hpd.series(dtype=object, elements=st.text(max_size=5)),
+    st.lists(st.integers(0, 9) | st.none(), max_size=6).map(lambda xs: pd.Series(pd.array(xs, dtype="Int64"))),
+    st.lists(st.booleans() | st.none(), max_size=6).map(lambda xs: pd.Series(pd.array(xs, dtype="boolean"))),
+    st.lists(st.text(max_size=4) | st.none(), max_size=6).map(lambda xs: pd.Series(pd.array(xs, dtype="string"))),
+    st.lists(st.sampled_from(["a", "b", "c"]), max_size=6).map(lambda xs: pd.Series(pd.Categorical(xs))),
+))
+def test_pandas_series_roundtrip(s):
+    assert eq(rt(s), s)
+
+
+@SETTINGS
+@given(st.one_of(
+    hpd.indexes(dtype=int, max_size=5),
+    hpd.indexes(dtype="datetime64[ns]", max_size=5),
+    hpd.range_indexes(max_size=6),
+    st.just(pd.MultiIndex.from_tuples([(1, "a"), (2, "b"), (3, "c")], names=["n", "l"])),
+))
+def test_pandas_index_roundtrip(idx):
+    assert eq(rt(idx), idx)
+
+
+@SETTINGS
+@given(hpd.data_frames([
+    hpd.column("i", dtype=int),
+    hpd.column("f", dtype=float),
+    hpd.column("s", dtype=object, elements=st.text(max_size=4)),
+]))
+def test_pandas_dataframe_roundtrip(df):
+    assert eq(rt(df), df)
+
+
+def test_fixed_types_deterministic():
+    """Explicit regression cases for every type this work fixed — a fast guard
+    that doesn't depend on hypothesis generating the right example."""
+    cases = [
+        _Color.RED, _Color.GREEN, _Size.L,                       # enum / IntEnum
+        zoneinfo.ZoneInfo("America/New_York"),
+        np.int64(-5), np.uint8(200), np.float32(1.5), np.complex128(1 + 2j), np.bool_(True),
+        np.datetime64("2020-01-01", "ns"), np.timedelta64(5, "D"),
+        np.float64("inf"), np.float64("-inf"),                    # non-finite numpy float
+        np.bytes_(b"hi"),
+        np.array([(1, 2.0)], dtype=[("a", "i4"), ("b", "f8")]),  # structured array
+        pd.Timestamp("2020-01-01 00:00:00.123456789"),
+        pd.Timestamp("2020-06-01", tz="US/Eastern"),
+        pd.Timedelta(days=2, seconds=5), pd.Period("2020-03", freq="M"),
+        pd.Interval(0, 5), pd.NaT,
+        pd.Series([1, None, 3], dtype="Int64", name="s"),
+        pd.Series(["a", None, "c"], dtype="string"),
+        pd.Series(pd.to_datetime(["2020-01-01"]).tz_localize("UTC")),
+        pd.Categorical(["a", "b", "a"], categories=["b", "a", "c"], ordered=True),
+        pd.Index([1, 2, 3], name="ix"),
+        pd.RangeIndex(2, 10, 2),
+        pd.DatetimeIndex(["2020-01-01", "2021-06-01"]),
+        pd.MultiIndex.from_tuples([(1, "a"), (2, "b")], names=["n", "l"]),
+    ]
+    for v in cases:
+        assert eq(rt(v), v), f"{type(v).__name__}: {v!r}"
+
+
+def test_pandas_dataframe_rich_dtypes_faithful():
+    """The column-wise serializer must preserve per-column dtypes exactly:
+    nullable Int64, categorical, and tz-aware datetime (the df.values approach
+    collapsed these)."""
+    df = pd.DataFrame({
+        "i": pd.array([1, None, 3], dtype="Int64"),
+        "cat": pd.Categorical(["a", "b", "a"], categories=["b", "a", "c"], ordered=True),
+        "dt": pd.to_datetime(["2020-01-01", "2020-06-01", "2021-01-01"]).tz_localize("UTC"),
+        "f": [1.5, 2.5, 3.5],
+    })
+    out = rt(df)
+    pd.testing.assert_frame_equal(out, df)
+    assert list(out.dtypes.astype(str)) == list(df.dtypes.astype(str))


### PR DESCRIPTION
Answers two of your asks: **make the type coverage comprehensive** (via a generative property test) and **fix everything it finds** — including the DataFrame serializer (you chose the column-wise rewrite).

## The property test (the durable answer to "enough type coverage?")
`tests/test_roundtrip_property.py` uses `hypothesis` + its numpy/pandas extras to generate values across the whole zoo and assert `deserialize(serialize(x)) == x`. It turns coverage from a judgment call into an enforced law — and it immediately found a real bug (non-finite `np.float64`). `hypothesis` added to the dev extra.

## Fixes it drove
**Scalars / enums**
- `enum.Enum` recursed forever; `IntEnum` was coerced to `int` → dedicated `enum` handling before the primitive branch (refused in safe mode — reconstruction imports the class).
- `zoneinfo.ZoneInfo`, `pd.Period`, `np.datetime64`/`timedelta64` errored → dedicated serializers.
- **non-finite `np.float64`** (`inf`/`nan`): the float tag stored `repr(obj)` = `'np.float64(inf)'` (numpy 2.x) → unparseable. Now a canonical `'inf'`/`'-inf'`/`'nan'` token.
- numpy **structured/record arrays** (`dtype.descr`), `np.bytes_`.

**pandas containers** (were erroring or lossy)
- **Series**: exact dtype preserved — nullable `Int64`/`boolean`/`string`, categorical, and **tz-aware datetime** (a tz series' `.values` is a *naive* array, so branch on `obj.dtype`), plus name + index.
- **Index family** — `Index`/`RangeIndex`/`DatetimeIndex`/`MultiIndex`/`Period`/`Interval`/`Categorical` index.
- **Categorical** — categories + codes + ordered (order preserved).
- **DataFrame — column-wise rewrite** (index + per-column Series). The old `df.values` path collapsed every column to one dtype: a frame with `Int64`/categorical/tz-datetime columns came back with `Int64` **degraded to `object`**. Now byte-faithful across the dtype zoo.

## Verification
Property test (10) + full suite **1074 passed, 121 skipped**, green on both numpy 2.2/pandas 2.3 and **numpy 2.5/pandas 3.0** (pandas-3.x address variants registered). Accepted, documented coercions: `np.float64→float`, `np.str_→str` (value-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
