### PR TITLE
test: run duckdb/leveldb/fsspec through the shared engine contract battery

### DIFF
--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -39,6 +39,21 @@ except Exception as e:
 
 from hashstash.engines.shelve import ShelveHashStash
 
+import importlib
+
+
+def _optional_engine(module, clsname, dep):
+    """A TEST_CLASSES entry for an engine whose dependency is optional (and, for
+    leveldb/plyvel, not in the CI `dev` extra) — guard the IMPORT, not just the
+    test, so a missing dep skips cleanly instead of erroring at collection."""
+    try:
+        importlib.import_module(dep)
+        cls = getattr(importlib.import_module(module), clsname)
+        return pytest.param(cls, id=clsname)
+    except Exception as e:  # dep missing / import error
+        return pytest.param(None, marks=pytest.mark.skip(reason=f"{dep} unavailable: {e}"), id=clsname)
+
+
 TEST_CLASSES = [
     PairtreeHashStash,
     SqliteHashStash,
@@ -49,6 +64,15 @@ TEST_CLASSES = [
     pytest.param(MongoHashStash, marks=pytest.mark.skipif(not MONGO_AVAILABLE, reason=MONGO_SKIP_REASON)),
     JSONLHashStash,
     ShelveHashStash,
+    # newer general-purpose KV engines were only covered by their own test files,
+    # not this shared dict-contract battery — bring them in (guarded on optional
+    # deps). NOTE: DataFrameHashStash is intentionally NOT here: it is a
+    # specialized DataFrame store (values are wrapped as MetaDataFrame; scalar
+    # append-mode, assembly and version metadata don't apply), covered by its own
+    # tests/test_dataframes.py.
+    _optional_engine("hashstash.engines.duckdb_engine", "DuckDBHashStash", "duckdb"),
+    _optional_engine("hashstash.engines.leveldb", "LevelDBHashStash", "plyvel"),
+    _optional_engine("hashstash.engines.fsspec", "FsspecHashStash", "fsspec"),
 ]
 
 


### PR DESCRIPTION
Answering "have we added all engines to the test engine suite?" — **no, not all.** The `TestHashStash` battery runs the full dict contract (set/get/overwrite/delete/keys/values/items/large-data/append-mode/…) uniformly, but `TEST_CLASSES` only wired **9** engines. The newer general engines had only their own dedicated files and skipped this uniform coverage.

## Added to the shared battery
- **duckdb**, **leveldb**, **fsspec** — all pass the full contract (**+157 tests**).
- Guarded via `_optional_engine()`: the **import** is guarded, not just the test, so a missing optional dep — notably **plyvel**, which is deliberately not in the CI `dev` extra — skips cleanly instead of erroring at collection. fsspec runs against a plain local path (no fixture special-casing).

## Intentionally not added: `dataframe`
`DataFrameHashStash` is a **specialized DataFrame store** — values are wrapped as `MetaDataFrame`, and scalar append-mode, dataframe assembly, and version metadata don't apply (it fails 7 generic-contract tests it was never meant to satisfy). It's covered by its own `tests/test_dataframes.py` (39 tests). Forcing it through the generic battery would mean 7 permanent skips for no real signal.

Full suite: **1231 passed, 121 skipped** (was 1074 — the delta is the three engines' battery runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
