### PR TITLE
1.0.1 — recover pre-1.0 caches (key-encoding drift) + lmdb teardown fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ real pre-1.0 caches.
     rewrites, so a large stash is never churned.
   - **`stash.iter_recovered()`** streams `(key, value)` for every stored version.
   - **Loud warning:** `items()` now warns when keys enumerate but nothing resolves
-    (the drift signature) instead of silently looking empty.
+    (the drift signature) instead of silently looking empty. These data-integrity
+    warnings go out on both the logger (stays loud under `filterwarnings('ignore')`)
+    and as a catchable `HashStashWarning` (for `warnings.catch_warnings`).
 - **lmdb: no more teardown `TypeError`.** Abandoning a `keys()`/`items()` generator
   mid-iteration could raise "catching classes that do not inherit from
   BaseException" during interpreter shutdown (the `MapResizedError` handler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ real pre-1.0 caches.
     could not), returns a `{'total','migrated','failed','dest'}` report to diff
     against expected counts, and `dry_run=True` counts without writing (safe on a
     huge stash). It re-appends every stored version, so an append-mode source's
-    **edit history is preserved** (into an append-mode dest). If it finds nothing
-    but a sibling layout dir has data, it warns that the source was opened with the
-    wrong `b64`/`compress`/engine kwargs (the layout is encoded in the path).
+    **edit history is preserved** (into an append-mode dest). `dest` may be a path
+    string/`Path` — a stash is built there **inheriting the source layout**
+    (engine/serializer/compress/b64) so the data reads back the same way; a
+    non-stash, non-path `dest` now raises `TypeError` up front instead of silently
+    failing every write. The report includes `first_error`, and an all-failed run
+    warns loudly. If it finds nothing but a sibling layout dir has data, it warns
+    that the source was opened with the wrong `b64`/`compress`/engine kwargs (the
+    layout is encoded in the path).
     *(Return type changed from the dest stash to the report dict —
     `report['dest']` holds the destination.)*
   - **`legacy_read=True`** on a stash falls back to a decode-and-match read of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## Unreleased
 
+## 1.0.1 — 2026-07-05
+
+Fixes a release-critical backward-compat break found by production consumers on
+real pre-1.0 caches.
+
+- **Recover caches written by an older hashstash.** The cache-key encoding drifted
+  across versions, so a pre-1.0 cache would *enumerate* (`keys()`/`len()` work)
+  but `get()`/`in`/`items()` silently missed every entry — `encode_key(key)` now
+  hashes to a different address than where the value was stored. Fresh 1.0 caches
+  were never affected. Recovery:
+  - **`stash.migrate(dest=..., dry_run=True/False)`** now reads via the raw stored
+    entries (so it recovers a drifted cache, which the old `items()`-based migrate
+    could not), returns a `{'total','migrated','failed','dest'}` report to diff
+    against expected counts, and `dry_run=True` counts without writing (safe on a
+    huge stash). *(Return type changed from the dest stash to the report dict —
+    `report['dest']` holds the destination.)*
+  - **`legacy_read=True`** on a stash falls back, on a `get()` miss, to a
+    decode-and-match read of the old-format entry. Read-only — it never rewrites,
+    so a large stash is never churned.
+  - **`stash.iter_recovered()`** streams `(key, value)` for every stored version.
+  - **Loud warning:** `items()` now warns when keys enumerate but nothing resolves
+    (the drift signature) instead of silently looking empty.
+- **lmdb: no more teardown `TypeError`.** Abandoning a `keys()`/`items()` generator
+  mid-iteration could raise "catching classes that do not inherit from
+  BaseException" during interpreter shutdown (the `MapResizedError` handler
+  resolved the class via attribute lookup on a half-cleared module); the exception
+  classes are now bound to locals.
+- Docs: a relative `root_dir` resolves under `~/.cache/hashstash` (not the CWD) —
+  now called out explicitly.
+
+Upgrading from a pre-1.0 cache: `report = old.migrate(dest=new, dry_run=True)` to
+count, then `dry_run=False` to recover. Or open with `legacy_read=True`. Note the
+`b64` default is `False` in 1.0 and is part of the on-disk path, so a cache
+written under the old `b64=True` default also needs `b64=True` (or migration).
+
 ## 1.0.0 — 2026-07-05
 
 First stable release. Consolidates the serializer type-coverage + speed work,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ real pre-1.0 caches.
     entries (so it recovers a drifted cache, which the old `items()`-based migrate
     could not), returns a `{'total','migrated','failed','dest'}` report to diff
     against expected counts, and `dry_run=True` counts without writing (safe on a
-    huge stash). *(Return type changed from the dest stash to the report dict —
+    huge stash). It re-appends every stored version, so an append-mode source's
+    **edit history is preserved** (into an append-mode dest). If it finds nothing
+    but a sibling layout dir has data, it warns that the source was opened with the
+    wrong `b64`/`compress`/engine kwargs (the layout is encoded in the path).
+    *(Return type changed from the dest stash to the report dict —
     `report['dest']` holds the destination.)*
-  - **`legacy_read=True`** on a stash falls back, on a `get()` miss, to a
-    decode-and-match read of the old-format entry. Read-only — it never rewrites,
-    so a large stash is never churned.
+  - **`legacy_read=True`** on a stash falls back to a decode-and-match read of the
+    old-format entry — covering `get()`, `key in stash`, and `items()` (so the
+    common `if key in stash: stash[key]` hot path works). Read-only — it never
+    rewrites, so a large stash is never churned.
   - **`stash.iter_recovered()`** streams `(key, value)` for every stored version.
   - **Loud warning:** `items()` now warns when keys enumerate but nothing resolves
     (the drift signature) instead of silently looking empty.

--- a/hashstash/__init__.py
+++ b/hashstash/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 from .constants import *
 from .config import *
 from .hashstash import *

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -182,6 +182,14 @@ class _MissingType:
 _MISSING = _MissingType()
 
 
+class HashStashWarning(UserWarning):
+    """Category for hashstash's user-actionable, data-integrity warnings (an
+    unreadable pre-1.0 cache, a wrong-layout migrate). Emitted via warnings.warn
+    AND the logger: the logger keeps it loud on stderr even when a consumer has
+    filterwarnings('ignore'), while the warning lets programmatic consumers catch
+    it with warnings.catch_warnings(record=True)."""
+
+
 class HashStashCachedError(Exception):
     """Raised for a cached exception whose original type couldn't be
     reconstructed (e.g. a non-importable custom exception)."""
@@ -1482,13 +1490,23 @@ class BaseHashStash(MutableMapping):
         if getattr(self, "_warned_unaddressable", False):
             return
         self._warned_unaddressable = True
-        log.warning(
+        self._warn_data_integrity(
             f"{type(self).__name__}: {n} stored keys enumerate but NONE could be "
             f"read — almost certainly a cache written by an OLDER hashstash whose "
             f"key encoding differs. Recover it with stash.migrate(dest=...) "
             f"(dry_run=True to count first), or open the stash with "
             f"legacy_read=True. Fresh writes are unaffected."
         )
+
+    @staticmethod
+    def _warn_data_integrity(msg):
+        # both channels on purpose: the logger stays loud on stderr even under
+        # filterwarnings('ignore') (common in ML stacks); the warning lets
+        # programmatic consumers catch it via warnings.catch_warnings.
+        import warnings
+
+        log.warning(msg)
+        warnings.warn(msg, HashStashWarning, stacklevel=3)
 
     @log.debug
     def keys_l(self, **kwargs):
@@ -1902,7 +1920,7 @@ class BaseHashStash(MutableMapping):
                 and os.path.isdir(os.path.join(parent, d))
             ]
             if siblings:
-                log.warning(
+                self._warn_data_integrity(
                     f"migrate found 0 entries at {layout_dir}, but sibling layout "
                     f"dir(s) exist: {siblings}. The engine/serializer/encoding "
                     f"(e.g. b64) is part of the path — reopen the source with the "

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -365,9 +365,13 @@ class BaseHashStash(MutableMapping):
         ttl: Union[int, float, timedelta] = None,
         safe: bool = None,
         max_entries: int = None,
+        legacy_read: bool = False,
         _root_is_dir: bool = None,
         **kwargs,
     ) -> None:
+        # read caches whose keys were stored under an older encoding: on a get()
+        # miss, fall back to a decode-and-match scan (see _legacy_find). Read-only
+        self.legacy_read = legacy_read
         config = Config()
         # self.name = name if name is not None else self.name
 
@@ -766,6 +770,19 @@ class BaseHashStash(MutableMapping):
             **kwargs,
         )
         found = values is not None and (not isinstance(values, list) or bool(values))
+        if (
+            not found
+            and self.legacy_read
+            and unencoded_key is not None
+            and not with_metadata
+            and as_dataframe is None
+        ):
+            # the key may have been stored under an older encoding: find it by
+            # decode-and-match and read its value (read-only, no rewrite)
+            legacy = self._legacy_find(unencoded_key)
+            if legacy is not _MISSING:
+                self._stats["hits"] += 1
+                return self.serialize(legacy, as_string=True) if as_string else legacy
         self._stats["hits" if found else "misses"] += 1
         value = values[-1] if values else default
         return self.serialize(value, as_string=True) if as_string else value
@@ -1315,6 +1332,49 @@ class BaseHashStash(MutableMapping):
             for k in db:
                 yield k, db[k]
 
+    # --- legacy-cache recovery -------------------------------------------------
+    # A cache written by an OLDER hashstash whose key encoding differs (the
+    # serialized/canonical form of a key changed across versions) still
+    # decodes its keys — keys() works and len() is right — but get()/`in`/items()
+    # silently miss, because encode_key(key) now hashes to a DIFFERENT address
+    # than where the entry was stored. These read each entry via its STORED
+    # encoded key (from _keys()), which _get() hashes to the correct address,
+    # so they never depend on encode_key(key) still matching.
+
+    def iter_recovered(self):
+        """Yield (key, value) for every stored version by reading the engine's raw
+        (encoded_key, encoded_value) pairs (self._items()) and unwrapping the value
+        envelope — the read path never calls encode_key(key), so it works on a
+        cache from any hashstash version whose keys/values this version can still
+        decode. Yields each version (oldest-first) so migrate() into an
+        append-mode dest preserves history; a plain dest keeps the latest. Streams;
+        holds nothing in memory."""
+        for enc_key, enc_val in self._items():
+            try:
+                key = self.decode_key(enc_key)
+                values, _ = _unwrap_envelope(self.decode_value(enc_val))
+            except Exception as e:
+                log.debug(f"recover: skipping an unreadable entry: {e}")
+                continue
+            for value in values:
+                yield key, value
+
+    def _legacy_find(self, unencoded_key):
+        """Read the latest value whose key was stored under an older encoding, by
+        scanning the raw entries and matching the decoded key (streaming,
+        read-only, no rewrite). O(n) per call — enabled per-stash with
+        legacy_read=True; for many reads or a large cache, migrate() once."""
+        want = serialize(unencoded_key, as_string=True, sort_keys=True)
+        for enc_key, enc_val in self._items():
+            try:
+                if serialize(self.decode_key(enc_key), as_string=True, sort_keys=True) == want:
+                    values, _ = _unwrap_envelope(self.decode_value(enc_val))
+                    if values:
+                        return values[-1]
+            except Exception:
+                continue
+        return _MISSING
+
     def _ttl_after(self, after, kwargs=None):
         """Effective 'after' floor for reads: an explicit after wins; otherwise
         the ttl floor applies unless apply_ttl=False was passed (prune() needs
@@ -1367,7 +1427,9 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def items(self, all_results=None, with_metadata=False, **kwargs):
+        n_keys = n_yield = 0
         for key in self.keys():
+            n_keys += 1
             vals = self.get_all(
                 key,
                 all_results=all_results,
@@ -1376,7 +1438,26 @@ class BaseHashStash(MutableMapping):
             )
             if vals is not None:
                 for val in vals:
+                    n_yield += 1
                     yield key, val
+        if n_keys and not n_yield and not self.legacy_read and not self.ttl:
+            # keys enumerate but NONE resolve to a value: the tell-tale sign of a
+            # cache written by an older hashstash whose key encoding differs.
+            # Warn loudly rather than silently look empty (which risks re-spending
+            # the budget that built the cache).
+            self._warn_unaddressable(n_keys)
+
+    def _warn_unaddressable(self, n):
+        if getattr(self, "_warned_unaddressable", False):
+            return
+        self._warned_unaddressable = True
+        log.warning(
+            f"{type(self).__name__}: {n} stored keys enumerate but NONE could be "
+            f"read — almost certainly a cache written by an OLDER hashstash whose "
+            f"key encoding differs. Recover it with stash.migrate(dest=...) "
+            f"(dry_run=True to count first), or open the stash with "
+            f"legacy_read=True. Fresh writes are unaffected."
+        )
 
     @log.debug
     def keys_l(self, **kwargs):
@@ -1726,14 +1807,46 @@ class BaseHashStash(MutableMapping):
             if predicate(key):
                 yield key, self[key]
 
-    def migrate(self, dest=None, **kwargs):
-        """Copy every entry from this stash into dest. If dest is None, kwargs are forwarded to
-        HashStash() to construct a new stash (e.g. engine='jsonl'). Returns the destination stash."""
-        if dest is None:
+    def migrate(self, dest=None, dry_run=False, **kwargs):
+        """Copy every entry into ``dest``, reading via the raw (encoded) entries
+        so it also RECOVERS a cache written by an older hashstash that
+        ``items()``/``get()`` now silently miss (the key encoding changed across
+        versions — keys still decode, but ``encode_key(key)`` hashes elsewhere).
+
+        dest: destination HashStash; if None, kwargs build one (e.g.
+        ``engine='jsonl'``). dry_run: count only, no writes — safe on a huge
+        stash, and lets you diff the counts against an expected total first.
+
+        Returns a report ``{'total', 'migrated', 'failed', 'dest'}`` (previously
+        returned the dest stash — it is now ``report['dest']``).
+        """
+        if not dry_run and dest is None:
             dest = HashStash(**kwargs)
-        for key, value in self.items():
-            dest[key] = value
-        return dest
+        total = migrated = failed = 0
+        for enc_key, enc_val in self._items():
+            total += 1
+            try:
+                key = self.decode_key(enc_key)
+                values, _ = _unwrap_envelope(self.decode_value(enc_val))
+            except Exception as e:
+                log.debug(f"migrate: skipping an unreadable entry: {e}")
+                failed += 1
+                continue
+            for value in values:  # each stored version (oldest-first)
+                if dry_run:
+                    migrated += 1
+                    continue
+                try:
+                    dest[key] = value
+                    migrated += 1
+                except Exception as e:
+                    log.debug(f"migrate: could not re-store an entry: {e}")
+                    failed += 1
+        log.info(
+            f"migrate(dry_run={dry_run}): {migrated} migrated, {failed} failed "
+            f"/ {total} entries"
+        )
+        return {"total": total, "migrated": migrated, "failed": failed, "dest": dest}
 
     def prune(self, older_than=None, dry_run=True):
         """Delete entries where the latest-write timestamp is older than ``older_than`` (a

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -1196,7 +1196,13 @@ class BaseHashStash(MutableMapping):
             # storage-level existence isn't enough: an expired entry must read
             # as absent everywhere, or get_set/run would trust a dead key
             return self.get(unencoded_key, default=_MISSING) is not _MISSING
-        return self._has(self.encode_key(unencoded_key))
+        if self._has(self.encode_key(unencoded_key)):
+            return True
+        if self.legacy_read:
+            # the hot path is `if key in stash: stash[key]` — legacy_read must
+            # cover membership too, or old-format entries still read as absent
+            return self._legacy_find(unencoded_key) is not _MISSING
+        return False
 
     @log.debug
     def encode_key(self, unencoded_key: Any) -> Union[str, bytes]:
@@ -1341,15 +1347,23 @@ class BaseHashStash(MutableMapping):
     # encoded key (from _keys()), which _get() hashes to the correct address,
     # so they never depend on encode_key(key) still matching.
 
+    def _raw_items(self):
+        """Raw (encoded_key, encoded_value) pairs including ALL stored versions.
+        Engines whose _items() takes all_results (pairtree) default to latest-only,
+        which silently dropped history during recovery — ask for everything."""
+        try:
+            return self._items(all_results=True)
+        except TypeError:
+            return self._items()
+
     def iter_recovered(self):
         """Yield (key, value) for every stored version by reading the engine's raw
-        (encoded_key, encoded_value) pairs (self._items()) and unwrapping the value
-        envelope — the read path never calls encode_key(key), so it works on a
-        cache from any hashstash version whose keys/values this version can still
-        decode. Yields each version (oldest-first) so migrate() into an
-        append-mode dest preserves history; a plain dest keeps the latest. Streams;
-        holds nothing in memory."""
-        for enc_key, enc_val in self._items():
+        (encoded_key, encoded_value) pairs and unwrapping the value envelope — the
+        read path never calls encode_key(key), so it works on a cache from any
+        hashstash version whose keys/values this version can still decode. Yields
+        every version (oldest-first); migrate() re-appends them so history
+        survives. Streams; holds nothing in memory."""
+        for enc_key, enc_val in self._raw_items():
             try:
                 key = self.decode_key(enc_key)
                 values, _ = _unwrap_envelope(self.decode_value(enc_val))
@@ -1358,6 +1372,18 @@ class BaseHashStash(MutableMapping):
                 continue
             for value in values:
                 yield key, value
+
+    def _legacy_items(self, all_results=None):
+        """items() under legacy_read: every version (oldest-first) when
+        all_results, else the latest per key."""
+        if self._all_results(all_results):
+            yield from self.iter_recovered()
+            return
+        latest = {}  # canonical-key -> (key, value); iter_recovered is oldest-first
+        for key, value in self.iter_recovered():
+            latest[serialize(key, as_string=True, sort_keys=True)] = (key, value)
+        for key, value in latest.values():
+            yield key, value
 
     def _legacy_find(self, unencoded_key):
         """Read the latest value whose key was stored under an older encoding, by
@@ -1427,6 +1453,11 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def items(self, all_results=None, with_metadata=False, **kwargs):
+        if self.legacy_read and not with_metadata:
+            # read old-format entries the normal path can't address; reads raw, so
+            # it also covers any new-format entries (no double-yield)
+            yield from self._legacy_items(all_results=all_results)
+            return
         n_keys = n_yield = 0
         for key in self.keys():
             n_keys += 1
@@ -1823,7 +1854,7 @@ class BaseHashStash(MutableMapping):
         if not dry_run and dest is None:
             dest = HashStash(**kwargs)
         total = migrated = failed = 0
-        for enc_key, enc_val in self._items():
+        for enc_key, enc_val in self._raw_items():
             total += 1
             try:
                 key = self.decode_key(enc_key)
@@ -1837,16 +1868,48 @@ class BaseHashStash(MutableMapping):
                     migrated += 1
                     continue
                 try:
-                    dest[key] = value
+                    # append so multi-version (append-mode) source history survives
+                    # regardless of dest's append_mode; a single-version key just
+                    # lands once, so a plain latest-only cache migrates unchanged.
+                    dest.set(key, value, append=True)
                     migrated += 1
                 except Exception as e:
                     log.debug(f"migrate: could not re-store an entry: {e}")
                     failed += 1
+        if not total:
+            self._warn_empty_migrate()
         log.info(
             f"migrate(dry_run={dry_run}): {migrated} migrated, {failed} failed "
             f"/ {total} entries"
         )
         return {"total": total, "migrated": migrated, "failed": failed, "dest": dest}
+
+    def _warn_empty_migrate(self):
+        """Nothing to migrate — but if a SIBLING layout dir (same parent, different
+        engine/serializer/encoding suffix) holds data, the stash was almost
+        certainly opened with the wrong kwargs (e.g. b64 omitted): the layout is
+        encoded in the dirname, so this path resolves empty while the data sits
+        one dir over. Point the user at it instead of silently reporting 0."""
+        try:
+            here = str(self.path)
+            parent = os.path.dirname(os.path.dirname(here))  # .../<layout>/data.db
+            layout_dir = os.path.dirname(here)
+            if not os.path.isdir(parent):
+                return
+            siblings = [
+                d for d in os.listdir(parent)
+                if os.path.join(parent, d) != layout_dir
+                and os.path.isdir(os.path.join(parent, d))
+            ]
+            if siblings:
+                log.warning(
+                    f"migrate found 0 entries at {layout_dir}, but sibling layout "
+                    f"dir(s) exist: {siblings}. The engine/serializer/encoding "
+                    f"(e.g. b64) is part of the path — reopen the source with the "
+                    f"kwargs matching the intended layout dir, then migrate."
+                )
+        except Exception:
+            pass
 
     def prune(self, older_than=None, dry_run=True):
         """Delete entries where the latest-write timestamp is older than ``older_than`` (a

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -1869,15 +1869,35 @@ class BaseHashStash(MutableMapping):
         Returns a report ``{'total', 'migrated', 'failed', 'dest'}`` (previously
         returned the dest stash — it is now ``report['dest']``).
         """
-        if not dry_run and dest is None:
-            dest = HashStash(**kwargs)
+        # a bare path as dest: build a stash there that INHERITS this stash's
+        # layout (engine/serializer/compress/b64) so the data reads back the same
+        # way. Without this, dest[key]=value raised on the str for every entry and
+        # was swallowed to a silent {migrated:0, failed:N}.
+        if isinstance(dest, (str, os.PathLike)):
+            opts = self.to_dict()
+            opts["root_dir"] = str(dest)
+            opts.pop("filename", None)  # recompute from the new root_dir
+            opts.pop("is_tmp", None)  # a migration target is not a temp stash
+            opts.update(kwargs)
+            dest = HashStash(**opts)
+        if not dry_run:
+            if dest is None:
+                dest = HashStash(**kwargs)
+            elif not isinstance(dest, BaseHashStash):
+                raise TypeError(
+                    f"migrate(dest=...) expects a HashStash or a path str/Path, "
+                    f"not {type(dest).__name__}"
+                )
         total = migrated = failed = 0
+        first_error = None
         for enc_key, enc_val in self._raw_items():
             total += 1
             try:
                 key = self.decode_key(enc_key)
                 values, _ = _unwrap_envelope(self.decode_value(enc_val))
             except Exception as e:
+                if first_error is None:
+                    first_error = f"decode: {type(e).__name__}: {e}"
                 log.debug(f"migrate: skipping an unreadable entry: {e}")
                 failed += 1
                 continue
@@ -1892,15 +1912,29 @@ class BaseHashStash(MutableMapping):
                     dest.set(key, value, append=True)
                     migrated += 1
                 except Exception as e:
+                    if first_error is None:
+                        first_error = f"write: {type(e).__name__}: {e}"
                     log.debug(f"migrate: could not re-store an entry: {e}")
                     failed += 1
         if not total:
             self._warn_empty_migrate()
+        elif not dry_run and migrated == 0 and failed:
+            # every entry failed — surface it loudly instead of debug-only logs
+            self._warn_data_integrity(
+                f"migrate wrote 0 of {total} entries (all failed). First error: "
+                f"{first_error}"
+            )
         log.info(
             f"migrate(dry_run={dry_run}): {migrated} migrated, {failed} failed "
             f"/ {total} entries"
         )
-        return {"total": total, "migrated": migrated, "failed": failed, "dest": dest}
+        return {
+            "total": total,
+            "migrated": migrated,
+            "failed": failed,
+            "first_error": first_error,
+            "dest": dest,
+        }
 
     def _warn_empty_migrate(self):
         """Nothing to migrate — but if a SIBLING layout dir (same parent, different

--- a/hashstash/engines/lmdb.py
+++ b/hashstash/engines/lmdb.py
@@ -69,17 +69,23 @@ class LMDBHashStash(BaseHashStash):
     @contextmanager
     def get_transaction(self, write=False):
         import lmdb
+        # bind the exception classes to LOCALS: if a keys()/items() generator is
+        # abandoned mid-iteration and finalized during interpreter teardown, an
+        # `except lmdb.MapResizedError` attribute lookup resolves on a half-cleared
+        # module and raised "catching classes that do not inherit from
+        # BaseException". Locals captured in the frame stay valid.
+        _MapResized, _LmdbError = lmdb.MapResizedError, lmdb.Error
         max_retries = 3
         for attempt in range(max_retries):
             try:
                 with self.get_db().begin(write=write) as txn:
                     yield txn
                 break
-            except lmdb.MapResizedError:
+            except _MapResized:
                 # another process grew the shared map; adopt the new size + retry
                 self._adopt_mapsize()
                 continue
-            except lmdb.Error as e:
+            except _LmdbError as e:
                 log.debug(f"LMDB transaction error (attempt {attempt + 1}/{max_retries}): {e}")
                 if attempt == max_retries - 1:
                     raise
@@ -131,22 +137,25 @@ class LMDBHashStash(BaseHashStash):
         that get_transaction gives reads.
         """
         import lmdb
+        _MapFull, _MapResized, _LmdbError = (
+            lmdb.MapFullError, lmdb.MapResizedError, lmdb.Error
+        )
         max_retries = 3
         attempt = 0
         while True:
             try:
                 with self.get_db().begin(write=True) as txn:
                     return fn(txn)
-            except lmdb.MapFullError:
+            except _MapFull:
                 # subclass of lmdb.Error, so this must come first. Don't drop the
                 # env: grow it in place and retry the operation.
                 self._grow_map()  # raises if the cap is hit
-            except lmdb.MapResizedError:
+            except _MapResized:
                 # another process grew the shared map; adopt the new size and
                 # retry (must precede the generic lmdb.Error branch, whose
                 # drop-and-reopen-at-stale-size lost the write).
                 self._adopt_mapsize()
-            except lmdb.Error as e:
+            except _LmdbError as e:
                 attempt += 1
                 log.debug(f"LMDB write error (attempt {attempt}/{max_retries}): {e}")
                 if attempt >= max_retries:

--- a/tests/test_legacy_recovery.py
+++ b/tests/test_legacy_recovery.py
@@ -11,7 +11,7 @@ import tempfile
 
 import pytest
 
-from hashstash import HashStash
+from hashstash import HashStash, HashStashWarning
 
 ENGINES = ["lmdb", "pairtree", "sqlite", "memory"]
 
@@ -118,10 +118,17 @@ def test_migrate_warns_when_layout_kwargs_wrong(caplog):
 
 
 def test_items_warns_loudly_when_unaddressable(caplog):
+    import warnings
+
     s, _root, _orig = _drifted_stash("memory")
     with caplog.at_level(logging.WARNING, logger="hashstash"):
-        list(s.items())
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            list(s.items())
+    # loud on the logger (survives filterwarnings('ignore')) ...
     assert any("OLDER hashstash" in r.message for r in caplog.records)
+    # ... and catchable programmatically via a typed warning
+    assert any(issubclass(x.category, HashStashWarning) for x in w)
 
 
 def test_no_false_warning_on_a_healthy_stash(caplog):

--- a/tests/test_legacy_recovery.py
+++ b/tests/test_legacy_recovery.py
@@ -69,6 +69,54 @@ def test_legacy_read_flag_reads_through_drift(engine):
     assert s2.get({"model": "gpt", "idx": 999}, "MISS") == "MISS"  # genuine miss
 
 
+@pytest.mark.parametrize("engine", ENGINES)
+def test_legacy_read_covers_contains_and_items(engine):
+    # the real hot path is `if key in stash: stash[key]` — legacy_read must cover
+    # __contains__ and items(), not just __getitem__
+    s, root, orig = _drifted_stash(engine)
+    s2 = HashStash(engine=engine, root_dir=root, dbname=s.dbname, legacy_read=True)
+    s2.encode_key = lambda k: orig(k) + b"DRIFT"
+    assert {"model": "gpt", "idx": 5} in s2
+    assert {"model": "gpt", "idx": 999} not in s2
+    items = dict((tuple(sorted(k.items())), v) for k, v in s2.items())
+    assert len(items) == 15
+    assert items[(("idx", 5), ("model", "gpt"))] == {"result": 50}
+
+
+@pytest.mark.parametrize("engine", ["pairtree", "lmdb"])
+def test_migrate_preserves_append_history(engine):
+    if engine == "lmdb":
+        pytest.importorskip("lmdb")
+    root = tempfile.mkdtemp()
+    src = HashStash(engine=engine, root_dir=root, append_mode=True)
+    src.clear()
+    src[{"k": 1}] = "v1"
+    src[{"k": 1}] = "v2"  # two versions of one key
+    orig = src.encode_key
+    src.encode_key = lambda k: orig(k) + b"DRIFT"  # drift
+    dest = HashStash(engine=engine, root_dir=tempfile.mkdtemp(), append_mode=True)
+    dest.clear()
+    rep = src.migrate(dest=dest, dry_run=False)
+    # both versions migrated (total counts raw entries: pairtree=2 version files,
+    # lmdb=1 envelope holding both — so assert on migrated + the preserved history)
+    assert rep["migrated"] == 2
+    assert dest.get_all({"k": 1}, all_results=True) == ["v1", "v2"]  # history kept
+
+
+def test_migrate_warns_when_layout_kwargs_wrong(caplog):
+    # the layout (b64/compress/...) is in the dirname; opening with the wrong
+    # kwargs resolves to an empty sibling path — warn instead of silent total=0
+    root = tempfile.mkdtemp()
+    good = HashStash(engine="pairtree", root_dir=root, compress="lz4", b64=True)
+    good.clear()
+    good[{"a": 1}] = "x"
+    wrong = HashStash(engine="pairtree", root_dir=root, compress="lz4", b64=False)
+    with caplog.at_level(logging.WARNING, logger="hashstash"):
+        rep = wrong.migrate(dry_run=True)
+    assert rep["total"] == 0
+    assert any("sibling layout" in r.message for r in caplog.records)
+
+
 def test_items_warns_loudly_when_unaddressable(caplog):
     s, _root, _orig = _drifted_stash("memory")
     with caplog.at_level(logging.WARNING, logger="hashstash"):

--- a/tests/test_legacy_recovery.py
+++ b/tests/test_legacy_recovery.py
@@ -103,6 +103,40 @@ def test_migrate_preserves_append_history(engine):
     assert dest.get_all({"k": 1}, all_results=True) == ["v1", "v2"]  # history kept
 
 
+@pytest.mark.parametrize("engine", ["lmdb", "pairtree"])
+def test_migrate_accepts_path_dest_inheriting_layout(engine):
+    # migrate(dest="/path") must build a stash there inheriting the SOURCE layout
+    # (engine/serializer/compress/b64), not silently fail on the str
+    if engine == "lmdb":
+        pytest.importorskip("lmdb")
+    s, _root, orig = _drifted_stash(engine)
+    destpath = tempfile.mkdtemp()
+    rep = s.migrate(dest=destpath, dry_run=False)
+    assert rep["migrated"] == 15 and rep["failed"] == 0
+    assert rep["first_error"] is None
+    dest = rep["dest"]
+    assert dest.engine == engine  # inherited, not the default engine
+    assert dest.get({"model": "gpt", "idx": 3}) == {"result": 30}
+
+
+def test_migrate_rejects_non_stash_dest():
+    # a non-stash, non-path dest used to be accepted, then every set() failed and
+    # was swallowed to {migrated:0, failed:N} — now it errors up front
+    s = HashStash(engine="memory", root_dir=tempfile.mkdtemp())
+    s.clear()
+    s[{"a": 1}] = "v"
+    with pytest.raises(TypeError, match="HashStash or a path"):
+        s.migrate(dest=12345)
+
+
+def test_migrate_report_includes_first_error_key():
+    s = HashStash(engine="memory", root_dir=tempfile.mkdtemp())
+    s.clear()
+    s[{"a": 1}] = "v"
+    rep = s.migrate(dest=HashStash(engine="memory", root_dir=tempfile.mkdtemp()))
+    assert "first_error" in rep and rep["first_error"] is None
+
+
 def test_migrate_warns_when_layout_kwargs_wrong(caplog):
     # the layout (b64/compress/...) is in the dirname; opening with the wrong
     # kwargs resolves to an empty sibling path — warn instead of silent total=0

--- a/tests/test_legacy_recovery.py
+++ b/tests/test_legacy_recovery.py
@@ -1,0 +1,85 @@
+"""Recovery of caches written by an older hashstash whose key encoding differs.
+
+The cache-key encoding (the serialized/canonical form of a key) drifted across
+versions, so a pre-1.0 cache enumerates (keys() decodes, len() is right) but
+get()/`in`/items() silently miss — encode_key(key) now hashes to a different
+address than where the entry was stored. We simulate that drift by patching
+encode_key AFTER writing (stored under the old form, read under the new one) and
+assert the recovery paths read through it."""
+import logging
+import tempfile
+
+import pytest
+
+from hashstash import HashStash
+
+ENGINES = ["lmdb", "pairtree", "sqlite", "memory"]
+
+
+def _drifted_stash(engine, n=15):
+    """Write n entries, then make encode_key produce a different address than
+    what is stored — reproducing a cross-version key-encoding change."""
+    if engine == "lmdb":
+        pytest.importorskip("lmdb")
+    root = tempfile.mkdtemp()
+    s = HashStash(engine=engine, root_dir=root)
+    s.clear()
+    for i in range(n):
+        s[{"model": "gpt", "idx": i}] = {"result": i * 10}
+    orig = s.encode_key
+    s.encode_key = lambda k: orig(k) + b"DRIFT"
+    return s, root, orig
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_break_is_reproduced(engine):
+    s, _root, _orig = _drifted_stash(engine)
+    # keys still enumerate, but the value is unaddressable via the new encoding
+    assert sum(1 for _ in s.keys()) == 15
+    assert s.get({"model": "gpt", "idx": 3}, "MISS") == "MISS"
+    assert sum(1 for _ in s.items()) == 0
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_iter_recovered_reads_through_drift(engine):
+    s, _root, _orig = _drifted_stash(engine)
+    rec = {tuple(sorted(k.items())): v for k, v in s.iter_recovered()}
+    assert len(rec) == 15
+    assert rec[(("idx", 7), ("model", "gpt"))] == {"result": 70}
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_migrate_recovers_into_fresh_stash(engine):
+    s, _root, _orig = _drifted_stash(engine)
+    dry = s.migrate(dry_run=True)
+    assert dry["migrated"] == 15 and dry["failed"] == 0
+    tgt = HashStash(engine="memory", root_dir=tempfile.mkdtemp())
+    tgt.clear()
+    rep = s.migrate(dest=tgt, dry_run=False)
+    assert rep["migrated"] == 15 and rep["failed"] == 0
+    assert tgt.get({"model": "gpt", "idx": 7}) == {"result": 70}  # normal read works
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_legacy_read_flag_reads_through_drift(engine):
+    s, root, orig = _drifted_stash(engine)
+    s2 = HashStash(engine=engine, root_dir=root, dbname=s.dbname, legacy_read=True)
+    s2.encode_key = lambda k: orig(k) + b"DRIFT"
+    assert s2.get({"model": "gpt", "idx": 7}, "MISS") == {"result": 70}
+    assert s2.get({"model": "gpt", "idx": 999}, "MISS") == "MISS"  # genuine miss
+
+
+def test_items_warns_loudly_when_unaddressable(caplog):
+    s, _root, _orig = _drifted_stash("memory")
+    with caplog.at_level(logging.WARNING, logger="hashstash"):
+        list(s.items())
+    assert any("OLDER hashstash" in r.message for r in caplog.records)
+
+
+def test_no_false_warning_on_a_healthy_stash(caplog):
+    s = HashStash(engine="memory", root_dir=tempfile.mkdtemp())
+    s.clear()
+    s[{"a": 1}] = "v"
+    with caplog.at_level(logging.WARNING, logger="hashstash"):
+        assert list(s.items()) == [({"a": 1}, "v")]
+    assert not any("OLDER hashstash" in r.message for r in caplog.records)


### PR DESCRIPTION
Release-critical fix found by both production consumers (malign-logits, largeliterarymodels) validating **real pre-1.0 caches**.

## The bug
The cache-key encoding drifted across versions, so a pre-1.0 cache **enumerates** (`keys()`/`len()` work) but `get()`/`in`/`items()` silently miss every entry — `encode_key(key)` now hashes to a different address than where the value was stored. Fresh 1.0 caches were never affected.

## Recovery (all read the raw stored entries — never re-encode)
- **`migrate(dest, dry_run)`** returns `{total, migrated, failed, first_error, dest}`; `dry_run` counts without writing. Re-appends every version (history preserved into an append-mode dest). `dest` may be a path (builds a stash there inheriting the source layout); a bad dest raises `TypeError`; an all-failed run warns loudly.
- **`legacy_read=True`** covers `get()`, `key in stash`, and `items()` (read-only, no rewrite).
- **`iter_recovered()`** streams `(key, value)` for every stored version.
- **Loud, catchable warning** (`HashStashWarning` + logger) when keys enumerate but nothing resolves, or a wrong-layout migrate finds a sibling data dir.

## Also
- lmdb: bind exception classes to locals so abandoning a `keys()`/`items()` generator no longer raises "catching classes that do not inherit from BaseException" during teardown.

## Validated on real production caches
- malign-logits: 213,081-entry lmdb (text + 151k-dim float32 logits) — migrate 213,081/213,081, native readback, `legacy_read` contract restored, `migrate(dest=path)` 1257/1257 inheriting layout.
- largeliterarymodels: 1472-entry pairtree + history — migrate byte-identical, history `[v1,v2]` preserved, get/`in`/items under `legacy_read`. Also retracted an initial perf concern (candidate is faster: 27 ms vs 51 ms cold import).

Full suite 1440 passing; 29 new recovery tests across lmdb/pairtree/sqlite/memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRqcpyxSXhxuANCqmkVVY
