### PR TITLE
fix: canonicalize non-str dict keys; detect partial key-encoding drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,17 @@ project lost a day to exactly that gap. Concretely:
   been ordered since 0.5.
   - `OrderedDict` is deliberately **excluded**: its `__eq__` is order-sensitive, so
     two differently-ordered `OrderedDict`s are *unequal* keys and collapsing them to
-    one address would be a false hit — worse than the miss being fixed.
+    one address would be a false hit — worse than the miss being fixed. This is
+    decided from the **live type** (`type(obj).__eq__ is dict.__eq__`), not from the
+    serialized type address, so `OrderedDict` *subclasses* are excluded too. Types
+    that keep their ordering in reduce state rather than in their items (e.g.
+    `bson.SON`) are excluded on the same grounds.
   - Values are unaffected: a dict value's insertion order is observable on
     round-trip and is still preserved. Only keys canonicalize.
+  - `keys()` now returns non-string-keyed dict keys in **canonical order**, not the
+    order they were stored in — `stash[{2:'b', 1:'a'}] = 1` enumerates back as
+    `{1:'a', 2:'b'}`. They are `==`-equal, so lookups are unaffected, but code that
+    reads `list(key.items())` positionally will see a different order.
   - *This changes the address of affected keys.* If you have stored keys containing
     non-string-keyed dicts, recover them with `legacy_read=True` or `migrate()`.
 - **Partial key-encoding drift now warns.** `items()` warned only when *no* key
@@ -63,6 +71,10 @@ project lost a day to exactly that gap. Concretely:
 - **An explicit `before`/`after` window is no longer mistaken for drift.**
   `items(after=...)` that legitimately filtered out every entry used to emit the
   "written by an OLDER hashstash" warning.
+- **`values()` now applies the time filter it was given.** It accepted `**kwargs`
+  and silently dropped them, so `values(after=X)` and `values_l(after=X)` returned
+  everything while `items(after=X)` filtered correctly — the same query spelled two
+  ways gave different answers.
 
 ## 1.0.1 — 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 ## Unreleased
 
+## 1.1.0 — 2026-07-26
+
+Minor rather than patch: this changes the stored address of a class of cache key
+for the second time in this lineage (0.5 was the first). The diff is small; the
+version number is signalling the address change, not the diff size. If your keys
+contain dicts with non-string keys, existing entries need `legacy_read=True` or
+`migrate()` to be visible after upgrading.
+
+### Dict key ordering: what changed in 0.5, and what was still broken until now
+
+**If you are upgrading a cache written by hashstash < 0.5, read this.** Before
+0.5, a dict used as a cache key was addressed **in its insertion order**:
+`{'model': m, 'prompt': p}` and `{'prompt': p, 'model': m}` were two *different*
+cache entries. Since 0.5 (commit `d7bbbab`), keys serialize with `sort_keys=True`,
+so equal dicts address to the same entry regardless of construction order.
+
+That was a deliberate fix — the old behaviour caused silent misses and duplicate
+recomputation — but it was **never stated plainly**: this changelog begins at
+1.0.0, and the 1.0.1 entry below refers to it only as "a latent key-address
+instability", which does not mention dicts or ordering. At least one downstream
+project lost a day to exactly that gap. Concretely:
+
+- A pre-0.5 entry is visible to 0.5+ **only if** the call site that wrote it
+  happened to build the dict in alphabetical order. Otherwise it still exists, still
+  enumerates via `keys()`, and silently fails to resolve.
+- Sets and frozensets were worse than insertion-order sensitive before 0.5: they
+  serialized in `PYTHONHASHSEED`-dependent iteration order, so a key containing a
+  set was not stable **across runs of the same interpreter**. A pre-0.5 cache with
+  set-containing keys is not reliably re-addressable at all; migrate it.
+- 0.5+ does **not** read pre-0.5 addresses natively. `legacy_read=True` reaches
+  them with a decode-and-match scan; `migrate()` re-addresses them permanently.
+
+### Fixed
+
+- **Dicts with non-string keys now canonicalize on the key path.** `sort_keys=True`
+  sorts JSON *object* keys, but a dict with non-string keys (or one holding a
+  reserved `__py__`/`__pytype__`/`__data__` marker) serializes to a JSON *list* of
+  `[key, value]` pairs, and `sort_keys` does not reorder array elements. So
+  `{1: 'a', 2: 'b'}` and `{2: 'b', 1: 'a'}` were **still** two different cache
+  entries on 1.0.1 — the 0.5 fix never reached this path. The same applied to dict
+  subclasses (`Counter`, `defaultdict`) via the reducer's `__dictitems__`. These
+  lists are now sorted by their serialized form, matching how set elements have
+  been ordered since 0.5.
+  - `OrderedDict` is deliberately **excluded**: its `__eq__` is order-sensitive, so
+    two differently-ordered `OrderedDict`s are *unequal* keys and collapsing them to
+    one address would be a false hit — worse than the miss being fixed.
+  - Values are unaffected: a dict value's insertion order is observable on
+    round-trip and is still preserved. Only keys canonicalize.
+  - *This changes the address of affected keys.* If you have stored keys containing
+    non-string-keyed dicts, recover them with `legacy_read=True` or `migrate()`.
+- **Partial key-encoding drift now warns.** `items()` warned only when *no* key
+  resolved, so a stash where (say) 20% of entries were unaddressable looked
+  perfectly healthy — the more dangerous shape, since total drift at least
+  announces itself. It now warns on any shortfall. The check counts **keys that
+  resolved**, not values yielded: `get_all()` returns every stored version, so on an
+  append-mode stash the value count routinely exceeds the key count and a
+  value-based comparison would stay silent exactly where there is most history to
+  lose (100 keys, 50 resolvable, 3 versions each → 150 values > 100 keys).
+- **An explicit `before`/`after` window is no longer mistaken for drift.**
+  `items(after=...)` that legitimately filtered out every entry used to emit the
+  "written by an OLDER hashstash" warning.
+
 ## 1.0.1 — 2026-07-05
 
 Fixes a release-critical backward-compat break found by production consumers on
@@ -51,7 +113,9 @@ written under the old `b64=True` default also needs `b64=True` (or migration).
 
 You may see **fewer keys after migrating** — that's a fix, not data loss. Some
 older caches wrote logically-identical keys under different addresses (a latent
-key-address instability that caused silent misses and duplicate re-computation);
+key-address instability that caused silent misses and duplicate re-computation —
+specifically, dict keys were addressed by insertion order before 0.5; see the
+Unreleased section above);
 1.0's deterministic canonical-key addressing collapses those duplicates. All
 stored *versions* are preserved — only the redundant addresses merge. (A
 production migration of 34 stashes saw one stash go from 24,856 to 23,056 keys,

--- a/hashstash/__init__.py
+++ b/hashstash/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 from .constants import *
 from .config import *
 from .hashstash import *

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -1456,7 +1456,12 @@ class BaseHashStash(MutableMapping):
 
     @log.debug
     def values(self, all_results=None, with_metadata=False, **kwargs):
-        for k, v in self.items(all_results=all_results, with_metadata=with_metadata):
+        # **kwargs used to be accepted and silently dropped, so values(after=X)
+        # (and values_l(after=X)) applied no time filter at all while items(after=X)
+        # did — the same call spelled two ways gave different answers.
+        for k, v in self.items(
+            all_results=all_results, with_metadata=with_metadata, **kwargs
+        ):
             yield v
 
     @log.debug

--- a/hashstash/engines/base.py
+++ b/hashstash/engines/base.py
@@ -1466,7 +1466,16 @@ class BaseHashStash(MutableMapping):
             # it also covers any new-format entries (no double-yield)
             yield from self._legacy_items(all_results=all_results)
             return
-        n_keys = n_yield = 0
+        # an explicit time window legitimately filters entries out, so it must not
+        # read as drift below
+        time_filtered = (
+            kwargs.get("before") is not None or kwargs.get("after") is not None
+        )
+        # count KEYS that resolved, not values yielded: get_all returns every stored
+        # version, so on an append-mode stash the value count routinely EXCEEDS the
+        # key count and can mask a large unresolvable fraction (100 keys, 50
+        # resolvable, 3 versions each -> 150 values > 100 keys). Keys vs keys.
+        n_keys = n_resolved = 0
         for key in self.keys():
             n_keys += 1
             vals = self.get_all(
@@ -1476,26 +1485,43 @@ class BaseHashStash(MutableMapping):
                 **kwargs,
             )
             if vals is not None:
+                n_resolved += 1
                 for val in vals:
-                    n_yield += 1
                     yield key, val
-        if n_keys and not n_yield and not self.legacy_read and not self.ttl:
-            # keys enumerate but NONE resolve to a value: the tell-tale sign of a
-            # cache written by an older hashstash whose key encoding differs.
-            # Warn loudly rather than silently look empty (which risks re-spending
-            # the budget that built the cache).
-            self._warn_unaddressable(n_keys)
+        if (
+            n_keys
+            and n_resolved < n_keys
+            and not self.legacy_read
+            and not self.ttl
+            and not time_filtered
+        ):
+            # keys enumerate but some (or all) don't resolve to a value: the
+            # tell-tale sign of a cache written by an older hashstash whose key
+            # encoding differs. PARTIAL drift is the more dangerous shape — it looks
+            # exactly like a healthy stash — so warn on any shortfall, not just a
+            # total one. Silence here risks re-spending the budget that built it.
+            self._warn_unaddressable(n_keys, n_resolved)
 
-    def _warn_unaddressable(self, n):
+    def _warn_unaddressable(self, n_keys, n_resolved=0):
         if getattr(self, "_warned_unaddressable", False):
             return
         self._warned_unaddressable = True
+        if n_resolved:
+            detail = (
+                f"{n_keys - n_resolved} of {n_keys} stored keys enumerate but could "
+                f"NOT be read ({n_resolved} resolved) — PARTIAL key-encoding drift, "
+                f"so this stash looks healthy while silently hiding entries"
+            )
+        else:
+            detail = (
+                f"{n_keys} stored keys enumerate but NONE could be read — almost "
+                f"certainly a cache written by an OLDER hashstash whose key "
+                f"encoding differs"
+            )
         self._warn_data_integrity(
-            f"{type(self).__name__}: {n} stored keys enumerate but NONE could be "
-            f"read — almost certainly a cache written by an OLDER hashstash whose "
-            f"key encoding differs. Recover it with stash.migrate(dest=...) "
-            f"(dry_run=True to count first), or open the stash with "
-            f"legacy_read=True. Fresh writes are unaffected."
+            f"{type(self).__name__}: {detail}. Recover it with "
+            f"stash.migrate(dest=...) (dry_run=True to count first), or open the "
+            f"stash with legacy_read=True. Fresh writes are unaffected."
         )
 
     @staticmethod

--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -202,9 +202,54 @@ def serialize_custom(obj: Any, sort_keys: bool = False) -> str:
     if sort_keys:
         # canonical KEY path: stdlib json with sorted keys so equal keys hash
         # identically regardless of insertion order OR whether orjson is present
-        return json.dumps(serialized, sort_keys=True)
+        return json.dumps(_canonicalize_key_items(serialized), sort_keys=True)
     # VALUE path: orjson-accelerated when available
     return _dumps_value(serialized)
+
+# Dicts whose keys aren't plain strings (or that hold a reserved marker key) are
+# serialized as a JSON LIST of [key, value] pairs, and dict subclasses carry their
+# contents in the reducer's '__dictitems__' list. json.dumps(sort_keys=True) sorts
+# object keys but NOT array elements, so those lists survived in insertion order
+# and two equal dicts addressed to two different cache entries — the same silent
+# miss that put sort_keys on the key path to begin with.
+#
+# Applied ONLY on the canonical key path: for a VALUE, a plain dict's insertion
+# order is observable on round-trip and must be preserved.
+#
+# OrderedDict is deliberately NOT sorted. Its __eq__ is order-sensitive, so two
+# differently-ordered OrderedDicts are UNEQUAL keys; collapsing them to one
+# address would be a false HIT, which is worse than the miss this fixes. Every
+# other dict subclass (Counter, defaultdict, ...) compares order-insensitively.
+_ORDER_SENSITIVE_REDUCERS = frozenset({"collections.OrderedDict"})
+
+
+def _entry_sort_key(entry):
+    # same comparator as IterableSerializer uses for sets: sort by the serialized
+    # form so ordering is stable across processes and PYTHONHASHSEED
+    return json.dumps(entry, sort_keys=True, default=str)
+
+
+def _canonicalize_key_items(obj):
+    """Recursively sort the list-encoded dict entries of an already-serialized
+    structure. Returns a new structure; does not mutate its input."""
+    if isinstance(obj, list):
+        return [_canonicalize_key_items(x) for x in obj]
+    if not isinstance(obj, dict):
+        return obj
+    # recurse first, so nested tagged dicts are canonical before the outer sort
+    out = {k: _canonicalize_key_items(v) for k, v in obj.items()}
+    pytype = obj.get("__pytype__")
+    if pytype == "dict" and isinstance(out.get("__items__"), list):
+        out["__items__"] = sorted(out["__items__"], key=_entry_sort_key)
+    elif (
+        pytype == "reducer"
+        and isinstance(out.get("__dictitems__"), list)
+        and obj.get("__py__") not in _ORDER_SENSITIVE_REDUCERS
+    ):
+        out["__dictitems__"] = sorted(out["__dictitems__"], key=_entry_sort_key)
+    # NB: '__listitems__' is never sorted — list order is semantic.
+    return out
+
 
 def stuff(obj, data=None):
     return _serialize_custom(obj, data=data)

--- a/hashstash/serializers/custom.py
+++ b/hashstash/serializers/custom.py
@@ -198,11 +198,16 @@ def serialize_custom(obj: Any, sort_keys: bool = False) -> str:
     # for values (not the canonical key path): keys stay on the audited full path.
     if not sort_keys and _is_json_native(obj):
         return _dumps_value(obj)
-    serialized = _serialize_custom(obj)
     if sort_keys:
         # canonical KEY path: stdlib json with sorted keys so equal keys hash
-        # identically regardless of insertion order OR whether orjson is present
-        return json.dumps(_canonicalize_key_items(serialized), sort_keys=True)
+        # identically regardless of insertion order OR whether orjson is present.
+        # The context flag lets _serialize_custom order list-encoded dict entries
+        # inline (it has the live type in hand, which a post-hoc walk of the
+        # serialized structure does not — see _may_sort_dict_entries).
+        with _canonical_key_path():
+            serialized = _serialize_custom(obj)
+        return json.dumps(serialized, sort_keys=True)
+    serialized = _serialize_custom(obj)
     # VALUE path: orjson-accelerated when available
     return _dumps_value(serialized)
 
@@ -213,14 +218,18 @@ def serialize_custom(obj: Any, sort_keys: bool = False) -> str:
 # and two equal dicts addressed to two different cache entries — the same silent
 # miss that put sort_keys on the key path to begin with.
 #
-# Applied ONLY on the canonical key path: for a VALUE, a plain dict's insertion
-# order is observable on round-trip and must be preserved.
-#
-# OrderedDict is deliberately NOT sorted. Its __eq__ is order-sensitive, so two
-# differently-ordered OrderedDicts are UNEQUAL keys; collapsing them to one
-# address would be a false HIT, which is worse than the miss this fixes. Every
-# other dict subclass (Counter, defaultdict, ...) compares order-insensitively.
-_ORDER_SENSITIVE_REDUCERS = frozenset({"collections.OrderedDict"})
+# Set ONLY for the canonical key path: for a VALUE, a dict's insertion order is
+# observable on round-trip and must be preserved.
+_KEYPATH_CTX = contextvars.ContextVar("hashstash_canonical_key", default=False)
+
+
+@contextmanager
+def _canonical_key_path():
+    token = _KEYPATH_CTX.set(True)
+    try:
+        yield
+    finally:
+        _KEYPATH_CTX.reset(token)
 
 
 def _entry_sort_key(entry):
@@ -229,26 +238,25 @@ def _entry_sort_key(entry):
     return json.dumps(entry, sort_keys=True, default=str)
 
 
-def _canonicalize_key_items(obj):
-    """Recursively sort the list-encoded dict entries of an already-serialized
-    structure. Returns a new structure; does not mutate its input."""
-    if isinstance(obj, list):
-        return [_canonicalize_key_items(x) for x in obj]
-    if not isinstance(obj, dict):
-        return obj
-    # recurse first, so nested tagged dicts are canonical before the outer sort
-    out = {k: _canonicalize_key_items(v) for k, v in obj.items()}
-    pytype = obj.get("__pytype__")
-    if pytype == "dict" and isinstance(out.get("__items__"), list):
-        out["__items__"] = sorted(out["__items__"], key=_entry_sort_key)
-    elif (
-        pytype == "reducer"
-        and isinstance(out.get("__dictitems__"), list)
-        and obj.get("__py__") not in _ORDER_SENSITIVE_REDUCERS
-    ):
-        out["__dictitems__"] = sorted(out["__dictitems__"], key=_entry_sort_key)
-    # NB: '__listitems__' is never sorted — list order is semantic.
-    return out
+def _may_sort_dict_entries(obj):
+    """Whether obj's entries can be reordered without changing what the object
+    MEANS as a cache key.
+
+    Decided from the LIVE TYPE, never from the serialized '__py__' address: a
+    denylist of type names silently misses SUBCLASSES. An OrderedDict subclass
+    inherits OrderedDict's order-sensitive __eq__ but reduces to its own address,
+    so a name-based check would sort it and collapse two UNEQUAL keys onto one
+    entry — a false HIT (silent wrong data), which is strictly worse than the
+    miss this whole change exists to fix.
+
+    `type(obj).__eq__ is dict.__eq__` is the exact test: it holds for dict and
+    defaultdict (order-insensitive) and fails for OrderedDict, its subclasses,
+    and bson.SON. Counter also fails it, which costs nothing — Counter's contents
+    reduce into '__args__' as a plain str-keyed dict and are canonicalized by
+    json.dumps(sort_keys=True) already."""
+    if not _KEYPATH_CTX.get():
+        return False
+    return type(obj).__eq__ is dict.__eq__
 
 
 def stuff(obj, data=None):
@@ -304,11 +312,18 @@ def _serialize_custom(obj: Any, data:Any=None) -> Any:
             return {k: _serialize_custom(v) for k, v in obj.items()}
         # Non-string keys (JSON would coerce them to strings) or reserved marker keys:
         # keep keys as a list of [key, value] pairs so their types survive the round-trip.
+        items = [
+            [_serialize_custom(k), _serialize_custom(v)] for k, v in obj.items()
+        ]
+        if _may_sort_dict_entries(obj):
+            # json.dumps(sort_keys=True) does not reorder a JSON array, so on the
+            # canonical key path these pairs must be ordered here or two equal
+            # dicts address to two different entries. `type(obj) is dict` is
+            # guaranteed above, so reordering is always safe here.
+            items.sort(key=_entry_sort_key)
         return {
             '__pytype__': 'dict',
-            '__items__': [
-                [_serialize_custom(k), _serialize_custom(v)] for k, v in obj.items()
-            ],
+            '__items__': items,
         }
 
     if isinstance(obj, list):
@@ -1021,9 +1036,17 @@ class ReducerSerializer(CustomSerializer):
         if len(reduced) > 3 and reduced[3] is not None:
             result['__listitems__'] = [_serialize_custom(x) for x in reduced[3]]
         if len(reduced) > 4 and reduced[4] is not None:
-            result['__dictitems__'] = [
+            dictitems = [
                 [_serialize_custom(k), _serialize_custom(v)] for k, v in reduced[4]
             ]
+            # Canonical key path only, and only when reordering cannot change what
+            # the object means (see _may_sort_dict_entries). '__state__' also vetoes
+            # it: bson.SON keeps its ordering in state ('_SON__keys'), so sorting
+            # the items alone would round-trip an object whose entries and whose
+            # recorded order disagree.
+            if _may_sort_dict_entries(obj) and '__state__' not in result:
+                dictitems.sort(key=_entry_sort_key)
+            result['__dictitems__'] = dictitems
         if len(reduced) > 5 and reduced[5] is not None:
             result['__state_setter__'] = get_obj_addr(reduced[5])
         return result

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -735,14 +735,53 @@ def test_dict_subclasses_canonicalize_except_ordered_dict(tmp_path):
     d1["a"], d1["b"] = 1, 2
     d2["b"], d2["a"] = 2, 1
     assert stash.encode_key(d1) == stash.encode_key(d2)
-    assert stash.encode_key(Counter({"a": 1, "b": 2})) == stash.encode_key(
-        Counter({"b": 2, "a": 1})
+    # a str-keyed Counter rides in __args__ as a JSON object and was already
+    # canonical via sort_keys; NON-str keys are what exercise the __items__ path
+    assert stash.encode_key(Counter({1: 2, 3: 4})) == stash.encode_key(
+        Counter({3: 4, 1: 2})
     )
 
     assert OrderedDict([("a", 1), ("b", 2)]) != OrderedDict([("b", 2), ("a", 1)])
     assert stash.encode_key(OrderedDict([("a", 1), ("b", 2)])) != stash.encode_key(
         OrderedDict([("b", 2), ("a", 1)])
     )
+
+
+def test_ordered_dict_subclass_is_not_collapsed(tmp_path):
+    """Order-sensitivity must be decided from the LIVE TYPE, not from the
+    serialized '__py__' address. An OrderedDict SUBCLASS reduces to its own
+    address, so a name-based denylist misses it, sorts its entries, and collapses
+    two UNEQUAL keys onto one entry — returning the wrong value, silently."""
+    from collections import OrderedDict
+
+    class MyOrderedDict(OrderedDict):
+        pass
+
+    k1 = MyOrderedDict([("a", 1), ("b", 2)])
+    k2 = MyOrderedDict([("b", 2), ("a", 1)])
+    assert k1 != k2
+
+    stash = HashStash(root_dir=str(tmp_path), engine="memory", b64=True)
+    stash[k1] = "value-for-k1"
+    assert stash.get(k2) is None, "false HIT: unequal keys collapsed to one entry"
+    stash[k2] = "value-for-k2"
+    assert stash.get(k1) == "value-for-k1"
+    assert len(stash) == 2
+
+
+def test_dict_subclass_with_ordering_in_state_round_trips(tmp_path):
+    """bson.SON keeps its ordering in __state__['_SON__keys'] rather than in its
+    reduce dictitems. Sorting the items alone would round-trip an object whose
+    entries and whose recorded order disagree, so __state__ vetoes the sort."""
+    SON = pytest.importorskip("bson").SON
+
+    key = SON([("b", 2), ("a", 1)])
+    stash = HashStash(root_dir=str(tmp_path), engine="memory", b64=True)
+    stash[key] = 1
+
+    back = list(stash.keys())[0]
+    assert back == key
+    assert list(back.items()) == list(key.items())
 
 
 def test_value_path_preserves_dict_insertion_order():
@@ -753,15 +792,20 @@ def test_value_path_preserves_dict_insertion_order():
     assert list(deserialize(serialize({2: "b", 1: "a"})).keys()) == [2, 1]
 
 
-def test_list_items_are_never_reordered():
-    """__listitems__ (and plain lists) carry semantic order; only dict entries sort."""
+def test_list_items_are_never_reordered(tmp_path):
+    """Sequences carry semantic order; only dict entries sort. A plain list and a
+    tuple do not exercise '__listitems__' at all (they serialize to a bare JSON
+    array and a '__py__: builtins.tuple' wrapper) — deque is the reducer-path
+    sequence that actually does."""
+    from collections import deque
+
     from hashstash import deserialize, serialize
 
     assert deserialize(serialize([3, 1, 2], sort_keys=True)) == [3, 1, 2]
-    assert deserialize(serialize(({"b": 1}, [3, 1, 2]), sort_keys=True)) == (
-        {"b": 1},
-        [3, 1, 2],
-    )
+    assert deserialize(serialize(deque([3, 1, 2]), sort_keys=True)) == deque([3, 1, 2])
+
+    stash = HashStash(root_dir=str(tmp_path), engine="memory", b64=True)
+    assert stash.encode_key(deque([3, 1, 2])) != stash.encode_key(deque([1, 2, 3]))
 
 
 def _strand_at_legacy_address(stash, key):
@@ -860,3 +904,17 @@ def test_explicit_time_window_is_not_mistaken_for_drift(tmp_path):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert list(stash.items(after=2**31)) == []
+
+
+def test_values_applies_the_same_time_filter_as_items(tmp_path):
+    """values() accepted **kwargs and silently dropped them, so values(after=X)
+    applied no filter while items(after=X) did — the same query spelled two ways
+    gave different answers."""
+    stash = HashStash(root_dir=str(tmp_path), engine="memory", b64=True)
+    for i in range(3):
+        stash[{"i": i}] = i
+
+    assert list(stash.items(after=2**31)) == []
+    assert list(stash.values(after=2**31)) == []
+    assert stash.values_l(after=2**31) == []
+    assert len(stash.values_l()) == 3

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -687,3 +687,176 @@ def test_redis_clear_scoped_to_namespace():
     finally:
         a.clear()
         b.clear()
+
+
+# --- Stage 5: canonical key ordering & partial-drift detection ---------------
+# Reported by a downstream consumer who lost a day to insertion-order-sensitive
+# dict keys across a 0.4.0 -> 1.0.1 upgrade.
+
+
+@pytest.mark.parametrize(
+    "a,b,label",
+    [
+        ({1: "a", 2: "b"}, {2: "b", 1: "a"}, "int-keyed dict"),
+        ({(1, 2): "a", (3, 4): "b"}, {(3, 4): "b", (1, 2): "a"}, "tuple-keyed dict"),
+        ({"a": 1, 1: "a"}, {1: "a", "a": 1}, "mixed-key dict"),
+        ({"__py__": 1, "z": 2}, {"z": 2, "__py__": 1}, "dict w/ reserved key"),
+        ({"k": {1: "a", 2: "b"}}, {"k": {2: "b", 1: "a"}}, "nested int-keyed dict"),
+    ],
+)
+def test_non_str_keyed_dicts_canonicalize_on_the_key_path(a, b, label):
+    """Dicts with non-string (or reserved) keys serialize to a JSON LIST of pairs,
+    which json.dumps(sort_keys=True) does NOT reorder — so two equal dicts used as
+    cache keys addressed to two different entries, silently."""
+    from hashstash import serialize
+
+    assert serialize(a, as_string=True, sort_keys=True) == serialize(
+        b, as_string=True, sort_keys=True
+    ), label
+
+
+def test_reordered_non_str_key_hits_the_same_stash_entry(tmp_path):
+    """End-to-end: the reproducer the consumer sent back."""
+    stash = HashStash(root_dir=str(tmp_path), engine="memory", b64=True)
+    stash[{"x": {1: "a", 2: "b"}}] = "hit"
+    assert stash.get({"x": {2: "b", 1: "a"}}) == "hit"
+
+
+def test_dict_subclasses_canonicalize_except_ordered_dict(tmp_path):
+    """Counter/defaultdict compare order-insensitively, so their keys must
+    canonicalize. OrderedDict.__eq__ IS order-sensitive: collapsing two
+    differently-ordered OrderedDicts to one address would be a false HIT, which is
+    worse than the miss being fixed here."""
+    from collections import Counter, OrderedDict, defaultdict
+
+    stash = HashStash(root_dir=str(tmp_path), engine="memory", b64=True)
+
+    d1, d2 = defaultdict(int), defaultdict(int)
+    d1["a"], d1["b"] = 1, 2
+    d2["b"], d2["a"] = 2, 1
+    assert stash.encode_key(d1) == stash.encode_key(d2)
+    assert stash.encode_key(Counter({"a": 1, "b": 2})) == stash.encode_key(
+        Counter({"b": 2, "a": 1})
+    )
+
+    assert OrderedDict([("a", 1), ("b", 2)]) != OrderedDict([("b", 2), ("a", 1)])
+    assert stash.encode_key(OrderedDict([("a", 1), ("b", 2)])) != stash.encode_key(
+        OrderedDict([("b", 2), ("a", 1)])
+    )
+
+
+def test_value_path_preserves_dict_insertion_order():
+    """Canonicalization is for KEYS only — a value's insertion order is observable
+    on round-trip and must survive."""
+    from hashstash import deserialize, serialize
+
+    assert list(deserialize(serialize({2: "b", 1: "a"})).keys()) == [2, 1]
+
+
+def test_list_items_are_never_reordered():
+    """__listitems__ (and plain lists) carry semantic order; only dict entries sort."""
+    from hashstash import deserialize, serialize
+
+    assert deserialize(serialize([3, 1, 2], sort_keys=True)) == [3, 1, 2]
+    assert deserialize(serialize(({"b": 1}, [3, 1, 2]), sort_keys=True)) == (
+        {"b": 1},
+        [3, 1, 2],
+    )
+
+
+def _strand_at_legacy_address(stash, key):
+    """Move an entry to the address a PRE-canonical hashstash would have written it
+    to (insertion-order serialization, no sort_keys). The entry still decodes and
+    still enumerates via keys() — it just no longer resolves, which is exactly the
+    drift signature a 0.4.0-written cache presents to 1.0.x.
+
+    Note the two things that do NOT work: deleting the entry removes it from keys()
+    too (n_keys drops, so no drift exists), and mangling the stored address makes
+    keys() raise on decode. Go through the engine-agnostic _get/_set/_del
+    primitives rather than stash.db — some backends (lmdb) expose an Environment
+    there, which does not support item assignment.
+
+    Caveats for anyone reusing this to test drift monitoring against real drift:
+    - it assumes one envelope per key, so it does not transfer to pairtree, which
+      stores one file per stored version (see the parametrize list below);
+    - pairtree also does not implement BaseHashStash._get at all — it overrides
+      get_all and the path-based read, so the base primitive raises
+      NotImplementedError there. Dormant in normal operation (nothing reaches that
+      call site), but it surfaces the moment you drive the raw primitives, which is
+      exactly what this helper does."""
+    canonical = stash.encode_key(key)
+    legacy = stash.encode(stash.serialize(key), as_string=stash.string_keys)
+    assert legacy != canonical, "key must not already be in canonical order"
+    stash._set(legacy, stash._get(canonical))
+    stash._del(canonical)
+
+
+# pairtree is deliberately absent: it stores one file per stored version rather
+# than one envelope per key, so relocating a raw entry to a legacy address is not
+# the same operation there. The warning itself is engine-independent (it lives in
+# BaseHashStash.items), so these three cover it.
+@pytest.mark.parametrize("engine", ["lmdb", "sqlite", "memory"])
+def test_partial_drift_warns_even_when_most_keys_resolve(engine, tmp_path):
+    """items() warned only when NOTHING resolved, so a stash with (say) 40% of its
+    entries unaddressable looked perfectly healthy. Partial drift is the more
+    dangerous shape precisely because it does not announce itself."""
+    from hashstash.engines.base import HashStashWarning
+
+    if engine == "lmdb":
+        pytest.importorskip("lmdb")
+    stash = HashStash(root_dir=str(tmp_path), engine=engine, b64=True)
+    stash.clear()
+    keys = [{"b": i, "a": i} for i in range(5)]  # non-alphabetical insertion order
+    for i, k in enumerate(keys):
+        stash[k] = i
+
+    for k in keys[:2]:
+        _strand_at_legacy_address(stash, k)
+
+    assert len(stash) == 5  # all five still enumerate
+    with pytest.warns(HashStashWarning, match="PARTIAL"):
+        resolved = list(stash.items())
+    assert len(resolved) == 3
+
+
+def test_append_mode_versions_do_not_mask_unresolvable_keys(tmp_path):
+    """The predicate must compare KEYS to keys, not values to keys: get_all returns
+    every stored version, so on an append-mode stash the value count exceeds the key
+    count and a naive `n_yield < n_keys` goes quiet exactly where there is most
+    history to lose."""
+    from hashstash.engines.base import HashStashWarning
+
+    stash = HashStash(
+        root_dir=str(tmp_path), engine="memory", b64=True, append_mode=True
+    )
+    keys = [{"b": i, "a": i} for i in range(4)]
+    for i, k in enumerate(keys):
+        for version in range(3):
+            stash[k] = f"{i}v{version}"
+
+    for k in keys[:2]:
+        _strand_at_legacy_address(stash, k)
+
+    n_keys = len(stash)
+    with pytest.warns(HashStashWarning, match="PARTIAL"):
+        pairs = list(stash.items(all_results=True))
+
+    assert n_keys == 4
+    # the exact case a `n_yield < n_keys` predicate would have stayed silent on:
+    # 6 values yielded from 2 resolvable keys still outnumbers the 4 stored keys
+    assert len(pairs) == 6 > n_keys
+    assert len({tuple(sorted(k.items())) for k, v in pairs}) == 2
+
+
+def test_explicit_time_window_is_not_mistaken_for_drift(tmp_path):
+    """A before/after filter legitimately hides entries — it must not trip the
+    drift warning."""
+    import warnings
+
+    stash = HashStash(root_dir=str(tmp_path), engine="memory", b64=True)
+    for i in range(3):
+        stash[{"i": i}] = i
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert list(stash.items(after=2**31)) == []


### PR DESCRIPTION
Reported by a downstream consumer who lost a day to insertion-order-sensitive dict keys across a 0.4.0 → 1.0.1 upgrade. Their reproducer:

```python
encode_key({'x': {1:'a', 2:'b'}}) == encode_key({'x': {2:'b', 1:'a'}})   # False on 1.0.1
```

## Canonical key ordering

`sort_keys=True` sorts JSON *object* keys, but a dict with non-string keys (or one holding a reserved `__py__`/`__pytype__`/`__data__` marker) serializes to a JSON *list* of `[key, value]` pairs — and `sort_keys` does not reorder array elements. So the 0.5 fix that made dict keys order-insensitive never reached this path. Same for dict subclasses via the reducer's `__dictitems__`. These lists now sort by serialized form, matching how set elements have been ordered since 0.5.

Two deliberate scope limits:

- **Key path only** (`sort_keys=True`), not inside `_serialize_custom`. A value dict's insertion order is observable on round-trip, so sorting unconditionally would have been a silent semantic change on the value path while fixing the key path.
- **Order-sensitive types excluded**, decided from the **live type** at serialize time (`type(obj).__eq__ is dict.__eq__`), never from the serialized `__py__` address. `OrderedDict`'s `__eq__` is order-sensitive, so two differently-ordered `OrderedDict`s are *unequal* keys — collapsing them to one address would be a false **hit**, which is strictly worse than the miss being fixed (a miss is silent absence; a false hit is silent wrong data). `dict`/`defaultdict` sort; `OrderedDict`, its subclasses, and `bson.SON` do not. `__listitems__` never sorts; list order is semantic.

  The first version of this PR got that wrong — see "Review" below.

## Partial-drift detection

`items()` warned only when *no* key resolved, so a stash with 20% of entries unaddressable looked perfectly healthy — the more dangerous shape, since total drift at least announces itself. It now warns on any shortfall.

The predicate counts **keys that resolved**, not values yielded. `get_all()` returns every stored version, so on an append-mode stash the value count routinely exceeds the key count and a value-based comparison stays silent exactly where there is most history to lose: 100 keys, 50 resolvable, 3 versions each → 150 values > 100 keys, no warning.

Found while testing: the old `n_yield == 0` check also **false-positived**. `items(after=<future ts>)` legitimately filters everything out, and the stash then announced it was written by an older hashstash. Now guarded on explicit `before`/`after`. The old predicate was wrong in both directions at once.

## Docs

The CHANGELOG now states plainly that pre-0.5 addressed dict keys by insertion order, that a pre-0.5 entry is visible today only if its call site happened to build alphabetically, that sets were `PYTHONHASHSEED`-dependent before 0.5 (so a pre-0.5 cache with set-containing keys is not reliably re-addressable at all), and that 0.5+ does **not** read pre-0.5 addresses natively except through `legacy_read`'s decode-and-match scan. The vague 1.0.1 "latent key-address instability" sentence now points at it.

Downstream's assessment was that this section is worth more to the next person than any of the three fixes.

## Tests

12 tests in a new stage-5 section of `tests/test_regressions.py`. All were confirmed to **fail against the pre-fix code** via `git stash`; the two that pass both ways are the ones guarding against regressions *from* this change (value-path order preservation, list order).

Simulating drift needs a specific construction, recorded in `_strand_at_legacy_address`: deleting an entry doesn't create drift (it leaves `keys()` too, so `n_keys` drops), and mangling the stored address makes `keys()` raise on decode. The entry has to be re-stored at the address a pre-canonical hashstash would have written it to — `stash.encode(stash.serialize(key), as_string=...)`, i.e. serialization *without* `sort_keys*`, on a key whose insertion order isn't alphabetical. It goes through the engine-agnostic `_get`/`_set`/`_del` primitives; reaching into `stash.db` works on `memory` and throws on lmdb.

Parametrized over lmdb, sqlite and memory. **pairtree is deliberately excluded**: it stores one file per stored version rather than one envelope per key, so relocating a raw entry isn't the same operation there. The warning itself lives in `BaseHashStash.items` and is engine-independent.

Not fixed, noted in the helper docstring: pairtree doesn't implement `BaseHashStash._get` at all — it overrides `get_all` and the path-based read, so the base primitive raises `NotImplementedError`. Dormant in normal operation (verified pairtree append mode end-to-end; that call site is never reached), but it surfaces the moment anyone drives the raw primitives — which is exactly what drift diagnostics do.

## Versioning

Minor rather than patch. This is the second key-address change in this lineage; the diff is small, but the version number is signalling the address change, not the diff size. Keys containing non-string-keyed dicts need `legacy_read=True` or `migrate()` to be visible after upgrading.


## Review

A code review of the first version of this PR caught a **critical false hit** in the very mechanism meant to prevent one, plus several smaller issues. All are fixed in a1b26f6.

**The blocker.** The `OrderedDict` exclusion was a denylist of serialized `__py__` addresses. But `OrderedDict.__reduce_ex__(2)` emits `self.__class__`, so an `OrderedDict` **subclass** reduced to its own address, missed the denylist, had its entries sorted, and inherited the order-sensitive `__eq__`:

```python
class MyOD(OrderedDict): pass
stash[MyOD([('a',1),('b',2)])] = 'x'
stash.get(MyOD([('b',2),('a',1)]))   # -> 'x'   (None before this PR)
```

Reachable beyond hand-rolled subclasses — `ruamel.yaml`'s `CommentedMap` derives from `OrderedDict`, and caching parsed configs as keys is ordinary. Fixed by deciding sortability from the live object rather than a serialized name.

**Also found and fixed:**

- `bson.SON` (a pymongo type, and pymongo is an engine dependency here) keeps its ordering in `__state__['_SON__keys']`, not in its reduce items. Sorting the items alone round-tripped an object whose entries and recorded order disagreed. `__state__` now vetoes the sort.
- **Performance.** The post-hoc canonicalization pass walked and rebuilt the whole serialized structure on every key encode — measured **+35%** on a large (~5k node) key. Moving the sort inline (which the live-type fix required anyway) removed the second walk: **626 µs vs 816 µs**, against 603 µs on `main`, so ~4% over baseline.
- **Three weak tests.** The `Counter` assertion was vacuous (str-keyed Counters ride in `__args__` and were already canonical pre-PR — now uses non-str keys). `test_list_items_are_never_reordered` never reached `__listitems__` at all, since a plain list serializes to a bare JSON array and a tuple to a `__py__` wrapper — now uses `deque`, the reducer-path sequence that actually emits it.
- **`values()` dropped its `**kwargs`**, so `values(after=X)` applied no time filter while `items(after=X)` did. Pre-existing, but it belongs with a change that fixes `before`/`after` handling in `items()`.
- CHANGELOG now notes that `keys()` returns non-string-keyed dict keys in canonical rather than stored order.

**Checked and found clean** (recording these so they aren't re-litigated): the `default=str` sort comparator cannot merge distinct entries, since `sorted()` returns a permutation — a collision yields a false miss, never a false hit. `_legacy_find`, `_legacy_items` and `migrate()` canonicalize both sides of their comparison and are improved by this change. `graph.py` never round-trips a key through decode-then-re-encode. 35+ key types were checked for encode∘decode fixpoint-ness. No realistic false positive was found for the new drift predicate beyond a narrow concurrency window (a delete landing between `keys()` and `get_all()`).

**Left alone, deliberately:** the drift warning latches once per stash instance, so one false positive silences later real warnings. Not changed here — removing the latch risks a warning per `items()` call. Worth revisiting separately.

## Test run

`1362 passed, 121 skipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

